### PR TITLE
fix(dashboard): plural counts, secret field styling, warn notes and guardrail docs

### DIFF
--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -13,7 +13,7 @@ them, in one of three phases:
 
 - **prompt**: after routing, before the request reaches the provider
 - **response**: on the complete response, before it reaches the client
-- **stream**: on each streamed event (or on the buffered stream, depending on the plugin)
+- **stream**: on each streamed event (or on the buffered stream, depending on the plugin) — only for requests with `stream: true`; a non-streaming request never runs a stream-phase guardrail
 
 A guardrail can edit content, add headers, reject the request with an error,
 answer it with a safe message, or let it through with a warning.
@@ -334,9 +334,9 @@ text split across two parts is not matched.
 | `case_insensitive` | No | `false` | Match regardless of letter case. |
 | `roles` | No | `["user"]` | Prompt messages the rules apply to: `system` (includes developer), `user`, `assistant`, `tool`. In the response phase the assistant text is always the target. |
 | `on_match` | No | `replace` | `replace` substitutes; `block` rejects with an error; `respond` answers with `message` as an assistant reply; `warn` continues and records the match. Only `replace` edits the text. |
-| `message` | No | `Request blocked by policy` | Error message for `block`, assistant reply for `respond`, audit note for `warn`. |
+| `message` | No | `Request blocked by policy` for `block` and `respond`, none for `warn` | Error message for `block`, assistant reply for `respond`, audit note for `warn`. A `warn` records a note only when you set one, so the outcome is not labelled as a block in the dashboard. |
 | `block_status` | No | phase default | One HTTP status code between 400 and 599 for `block`, for example `403`. Empty means 400 when the prompt is blocked, 502 when the response is blocked. |
-| `stream_lookbehind` | No | `64` | Characters of streamed text held back so a match spanning two chunks is still rewritten; set it to at least the longest find text. A match at the end of the text streamed so far is held until it stops growing, so an open-ended pattern such as `sk-[A-Za-z0-9]{20,}` masks the whole value when it is at most this long. Used by `replace` and `warn`. |
+| `stream_lookbehind` | No | `64` | Characters of streamed text held back so a match spanning two chunks is still rewritten; set it to at least the longest find text. A match at the end of the text streamed so far is held until it stops growing, so an open-ended pattern such as `sk-[A-Za-z0-9_-]{20,}` masks the whole value when it is at most this long — a longer value keeps the part beyond the lookbehind, so raise it above the longest secret you expect. Used by `replace` and `warn`. |
 
 In the stream phase, `replace` and `warn` transform events in flight with the
 configured lookbehind. `block` and `respond` buffer the whole stream so
@@ -480,6 +480,17 @@ types and counts, never the values, and errors from the analyzer never carry
 the text it was given. The analyzer receives the text in clear, so run it as
 a sidecar on the same host or reach it over `https://` or a private network.
 
+<Warning>
+  Anonymizing hides the values from the provider, not from your audit log.
+  `LOGGING_LOG_BODIES` defaults to `true`, and the stored `request_body` and
+  `response_body` are the ones the client sent and received, with the personal
+  data in clear — only the rewritten body kept under `request_revisions` is
+  anonymized. Set
+  [`LOGGING_LOG_BODIES=false`](/advanced/configuration#audit-logging) (or
+  `LOGGING_LOG_REVISION_BODIES=false` to drop just the rewritten copies) when
+  the audit store must not hold personal data.
+</Warning>
+
 <Tip>
   Start with an explicit `entities` list. With every type enabled, the
   analyzer's language model also reports `DATE_TIME`, `LOCATION`, `NRP`, and
@@ -489,7 +500,12 @@ a sidecar on the same host or reach it over `https://` or a private network.
   deployments. Some models, Claude among them, treat unexplained
   `<PERSON_1>`-style tokens with suspicion and may refuse to repeat them; a
   system prompt line such as `Values like <PERSON_1> are privacy placeholders;
-  use them as ordinary values` fixes that.
+  use them as ordinary values` fixes that. The analyzer's `PERSON` spans can
+  also swallow a neighbouring all-caps token (`TOOLESC Katarzyna` is reported
+  as one `PERSON`), so a `presidio` step that runs before a `string_replace`
+  step can replace the very text the later rule looks for; when a rule has to
+  see the original words, give the `string_replace` step the lower `order` so
+  it runs first, or add those words to `allow_list`.
 </Tip>
 
 In the stream phase, `anonymize` and `warn` transform events in flight in
@@ -506,7 +522,20 @@ phase puts the values back where the model repeats a placeholder, in text
 and in tool-call arguments, so the client sees its own data while the
 provider never does. Set `restore` on the instances in both phases: the
 prompt-phase instance records the values, the response-phase instance
-restores them. Only values from user messages, earlier assistant turns, and
+restores them.
+
+<Warning>
+  Pair the prompt-phase instance with a **response**-phase one. The response
+  phase covers both kinds of request — it buffers a streamed one — while a
+  stream-phase instance runs on streamed responses only. With a stream-phase
+  instance alone, a non-streaming request returns the raw `<PERSON_1>`
+  placeholders to the client and any personal data the model invented on its
+  own reaches the client unmasked. A stream-phase instance is the right choice
+  only when every request that needs restoring is streamed and delivery has to
+  stay incremental.
+</Warning>
+
+Only values from user messages, earlier assistant turns, and
 tool results are put back; a value from a system or developer message stays
 a placeholder, so a user cannot make the model reveal it. A value the model
 produced on its own is still anonymized on the way out. Such responses are
@@ -640,9 +669,12 @@ guardrails:
 ### Stream Phase: Redact In Flight and Judge the Whole Answer
 
 The same instance can be referenced in several phases. `mask-keys` transforms
-streamed chunks in flight (64 characters of lookbehind, so a key split across
-two chunks is still caught). `answer-judge` needs the whole answer, so it
-buffers the stream and the client receives it once the verdict is in.
+streamed chunks in flight; `stream_lookbehind` is how much text it holds back,
+so set it above the longest secret you expect (provider keys such as
+`sk-proj-…` and `sk-ant-…` run well past the 64-character default, and
+anything beyond the lookbehind reaches the client unmasked). `answer-judge`
+needs the whole answer, so it buffers the stream and the client receives it
+once the verdict is in.
 
 ```yaml
 guardrails:
@@ -654,8 +686,9 @@ guardrails:
       order: 10
       config:
         mode: "regex"
+        stream_lookbehind: 256
         rules: |
-          sk-[A-Za-z0-9]{20,} => [redacted]
+          sk-[A-Za-z0-9_-]{20,} => [redacted]
 
     - name: "answer-judge"
       type: "llm_judge"

--- a/docs/advanced/plugins.mdx
+++ b/docs/advanced/plugins.mdx
@@ -346,7 +346,7 @@ guardrails:
       config:                     # validated against the plugin's ConfigSchema
         mode: "regex"
         rules: |
-          sk-[A-Za-z0-9]{20,} => [redacted]
+          sk-[A-Za-z0-9_-]{20,} => [redacted]
 ```
 
 Rules from `config.yaml` are seeded into the managed default workflow at

--- a/internal/plugins/builtin/stringreplace/config.go
+++ b/internal/plugins/builtin/stringreplace/config.go
@@ -27,6 +27,17 @@ const (
 	DefaultStreamLookbehind = 64
 )
 
+// defaultMessage is the message an instance that configures none falls back
+// to: the block-phrased default for the outcomes that stop the request, and
+// none for warn, whose message is only an audit note and would otherwise read
+// as a block in the dashboard.
+func defaultMessage(onMatch string) string {
+	if onMatch == OnMatchWarn {
+		return ""
+	}
+	return DefaultMessage
+}
+
 // settings is the validated configuration.
 type settings struct {
 	rules           []rule
@@ -52,7 +63,7 @@ func decodeConfig(raw json.RawMessage) (settings, error) {
 	}
 	s.enforcement = pluginapi.Enforcement{
 		Action:      pluginapi.Action(s.onMatch),
-		Message:     cfg.String("message", DefaultMessage),
+		Message:     cfg.String("message", defaultMessage(s.onMatch)),
 		BlockStatus: cfg.BlockStatus("block_status"),
 	}
 	ruleLines := cfg.Lines("rules")

--- a/internal/plugins/builtin/stringreplace/config.go
+++ b/internal/plugins/builtin/stringreplace/config.go
@@ -27,13 +27,14 @@ const (
 	DefaultStreamLookbehind = 64
 )
 
-// defaultMessage is the message an instance that configures none falls back
-// to: the block-phrased default for the outcomes that stop the request, and
-// none for warn, whose message is only an audit note and would otherwise read
-// as a block in the dashboard.
-func defaultMessage(onMatch string) string {
-	if onMatch == OnMatchWarn {
-		return ""
+// enforcementMessage resolves the configured message. A blank one — unset, or
+// cleared in the dashboard — falls back to the block-phrased default for the
+// outcomes that stop the request, so a block never answers with an empty
+// error; warn keeps no note, since its message is only an audit note and the
+// default would read as a block in the dashboard.
+func enforcementMessage(configured, onMatch string) string {
+	if configured != "" || onMatch == OnMatchWarn {
+		return configured
 	}
 	return DefaultMessage
 }
@@ -63,7 +64,7 @@ func decodeConfig(raw json.RawMessage) (settings, error) {
 	}
 	s.enforcement = pluginapi.Enforcement{
 		Action:      pluginapi.Action(s.onMatch),
-		Message:     cfg.String("message", defaultMessage(s.onMatch)),
+		Message:     enforcementMessage(cfg.String("message", ""), s.onMatch),
 		BlockStatus: cfg.BlockStatus("block_status"),
 	}
 	ruleLines := cfg.Lines("rules")

--- a/internal/plugins/builtin/stringreplace/plugin.go
+++ b/internal/plugins/builtin/stringreplace/plugin.go
@@ -72,8 +72,10 @@ func (p *Plugin) Manifest() pluginapi.Manifest {
 				},
 			},
 			{
-				Key: "message", Label: "Message", Input: pluginapi.InputText, Default: DefaultMessage,
-				Help:        "Error message for block, assistant reply for respond, and audit note for warn.",
+				// No Default: the dashboard would store it with the instance, so a
+				// warn would carry the block-phrased text as its audit note.
+				Key: "message", Label: "Message", Input: pluginapi.InputText,
+				Help:        "Error message for block, assistant reply for respond, and audit note for warn. Left empty, block and respond fall back to " + DefaultMessage + " and warn records no note.",
 				Placeholder: DefaultMessage,
 			},
 			pluginapi.BlockStatusField(),

--- a/internal/plugins/builtin/stringreplace/plugin_test.go
+++ b/internal/plugins/builtin/stringreplace/plugin_test.go
@@ -248,7 +248,9 @@ func TestOnPromptDecisions(t *testing.T) {
 		{"block default status", `{"rules": "ACME => x", "on_match": "block"}`, pluginapi.ActionBlock, 0, DefaultMessage, map[string]any{"matches": 3, "messages": 2}},
 		{"block custom", `{"rules": "ACME => x", "on_match": "block", "block_status": 446, "message": "nope"}`, pluginapi.ActionBlock, 446, "nope", map[string]any{"matches": 3, "messages": 2}},
 		{"respond", `{"rules": "ACME => x", "on_match": "respond", "message": "I cannot discuss that."}`, pluginapi.ActionRespond, 0, "", map[string]any{"matches": 3, "messages": 2}},
+		{"block empty message falls back", `{"rules": "ACME => x", "on_match": "block", "message": ""}`, pluginapi.ActionBlock, 0, DefaultMessage, map[string]any{"matches": 3, "messages": 2}},
 		{"warn keeps no default note", `{"rules": "ACME => x", "on_match": "warn", "roles": ["system"]}`, pluginapi.ActionWarn, 0, "", map[string]any{"matches": 1, "messages": 1}},
+		{"warn empty message stays empty", `{"rules": "ACME => x", "on_match": "warn", "roles": ["system"], "message": ""}`, pluginapi.ActionWarn, 0, "", map[string]any{"matches": 1, "messages": 1}},
 		{"warn custom note", `{"rules": "ACME => x", "on_match": "warn", "roles": ["system"], "message": "vendor name seen"}`, pluginapi.ActionWarn, 0, "vendor name seen", map[string]any{"matches": 1, "messages": 1}},
 		{"no match allows", `{"rules": "zzz => x", "on_match": "block"}`, pluginapi.ActionAllow, 0, "", nil},
 	}

--- a/internal/plugins/builtin/stringreplace/plugin_test.go
+++ b/internal/plugins/builtin/stringreplace/plugin_test.go
@@ -248,7 +248,8 @@ func TestOnPromptDecisions(t *testing.T) {
 		{"block default status", `{"rules": "ACME => x", "on_match": "block"}`, pluginapi.ActionBlock, 0, DefaultMessage, map[string]any{"matches": 3, "messages": 2}},
 		{"block custom", `{"rules": "ACME => x", "on_match": "block", "block_status": 446, "message": "nope"}`, pluginapi.ActionBlock, 446, "nope", map[string]any{"matches": 3, "messages": 2}},
 		{"respond", `{"rules": "ACME => x", "on_match": "respond", "message": "I cannot discuss that."}`, pluginapi.ActionRespond, 0, "", map[string]any{"matches": 3, "messages": 2}},
-		{"warn", `{"rules": "ACME => x", "on_match": "warn", "roles": ["system"]}`, pluginapi.ActionWarn, 0, DefaultMessage, map[string]any{"matches": 1, "messages": 1}},
+		{"warn keeps no default note", `{"rules": "ACME => x", "on_match": "warn", "roles": ["system"]}`, pluginapi.ActionWarn, 0, "", map[string]any{"matches": 1, "messages": 1}},
+		{"warn custom note", `{"rules": "ACME => x", "on_match": "warn", "roles": ["system"], "message": "vendor name seen"}`, pluginapi.ActionWarn, 0, "vendor name seen", map[string]any{"matches": 1, "messages": 1}},
 		{"no match allows", `{"rules": "zzz => x", "on_match": "block"}`, pluginapi.ActionAllow, 0, "", nil},
 	}
 	for _, tt := range tests {
@@ -454,7 +455,7 @@ func TestStreamEvents(t *testing.T) {
 			if tt.detail != nil && !reflect.DeepEqual(d.Detail, tt.detail) {
 				t.Errorf("end detail = %v, want %v", d.Detail, tt.detail)
 			}
-			if tt.end == pluginapi.ActionWarn && (d.Code != Code || d.Message != DefaultMessage) {
+			if tt.end == pluginapi.ActionWarn && (d.Code != Code || d.Message != "") {
 				t.Errorf("warn decision = %+v", d)
 			}
 		})

--- a/web/dashboard/messages/de.json
+++ b/web/dashboard/messages/de.json
@@ -53,7 +53,16 @@
   "playground_meta_status": "HTTP {status}",
   "playground_meta_duration": "{seconds}s",
   "playground_meta_tokens": "Eingabe {input} / Ausgabe {output}",
-  "playground_meta_events": "{count} Stream-Events",
+  "playground_meta_events": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} Stream-Event",
+        "count_plural=*": "{count} Stream-Events"
+      }
+    }
+  ],
   "navigation_audit_logs": "Audit-Logs",
   "navigation_usage": "Nutzung",
   "navigation_budgets": "Budgets",
@@ -444,7 +453,16 @@
       }
     }
   ],
-  "overview_mcp_attention": "{count} Server brauchen Aufmerksamkeit",
+  "overview_mcp_attention": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} Server braucht Aufmerksamkeit",
+        "count_plural=*": "{count} Server brauchen Aufmerksamkeit"
+      }
+    }
+  ],
   "overview_mcp_connected": "{connected} von {total} Servern verbunden",
   "overview_calendar_cost_year": "${total} im letzten Jahr",
   "overview_calendar_tokens_year": "{total} Tokens im letzten Jahr",
@@ -660,7 +678,16 @@
   "api_keys_show_inactive": "Inaktive anzeigen",
   "api_keys_path_filter_clear": "Nutzerpfad-Filter entfernen",
   "api_keys_no_match": "Keine API-Schlüssel entsprechen dem aktuellen Filter.",
-  "api_keys_hidden": "{count} inaktive Schlüssel sind ausgeblendet.",
+  "api_keys_hidden": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} inaktiver Schlüssel ist ausgeblendet.",
+        "count_plural=*": "{count} inaktive Schlüssel sind ausgeblendet."
+      }
+    }
+  ],
   "api_keys_empty": "Noch keine API-Schlüssel. Lege einen Schlüssel an, um loszulegen.",
   "api_keys_editor": "API-Schlüssel-Editor",
   "api_keys_done": "Erledigt, ich habe ihn gespeichert",
@@ -747,7 +774,16 @@
   "workflows_filter_label": "Workflows filtern",
   "workflows_empty": "Keine aktiven Workflows gefunden.",
   "workflows_no_match": "Keine Workflows entsprechen deinem Filter.",
-  "workflows_active_scopes": "{count} aktive Geltungsbereiche",
+  "workflows_active_scopes": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} aktiver Geltungsbereich",
+        "count_plural=*": "{count} aktive Geltungsbereiche"
+      }
+    }
+  ],
   "workflows_copy_id": "Workflow-ID kopieren",
   "workflows_id_copied": "Workflow-ID kopiert",
   "workflows_copy_id_failed": "Workflow-ID konnte nicht kopiert werden",
@@ -1065,7 +1101,16 @@
   "api_keys_effective_models_help": "Was eine Anfrage mit diesem Schlüssel tatsächlich aufrufen kann: die Richtlinien seines Nutzerpfads, seine eigenen erlaubten Modelle und modellseitige Richtlinien, kombiniert.",
   "api_keys_effective_all": "Alle Modelle",
   "api_keys_effective_none": "Keine",
-  "api_keys_effective_count": "{count} Modelle",
+  "api_keys_effective_count": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} Modell",
+        "count_plural=*": "{count} Modelle"
+      }
+    }
+  ],
   "api_keys_allowed_models_all": "Alle",
   "api_keys_edit_allowed_models": "Erlaubte Modelle bearbeiten",
   "api_keys_allowed_models_editor": "Editor für erlaubte Modelle",
@@ -1094,7 +1139,16 @@
   "users_column_effective": "Effektive Modelle",
   "users_effective_all": "Alle Modelle",
   "users_effective_none": "Keine",
-  "users_effective_count": "{count} Modelle",
+  "users_effective_count": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} Modell",
+        "count_plural=*": "{count} Modelle"
+      }
+    }
+  ],
   "users_effective_via": "über {path}",
   "users_no_models_warning": "Es blieben keine Modelle verfügbar: nichts in dieser Liste wird von den übergeordneten Gruppen erlaubt.",
   "users_column_keys": "API-Schlüssel",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -53,7 +53,16 @@
   "playground_meta_status": "HTTP {status}",
   "playground_meta_duration": "{seconds}s",
   "playground_meta_tokens": "{input} in / {output} out",
-  "playground_meta_events": "{count} stream events",
+  "playground_meta_events": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} stream event",
+        "count_plural=*": "{count} stream events"
+      }
+    }
+  ],
   "navigation_audit_logs": "Audit Logs",
   "navigation_usage": "Usage",
   "navigation_budgets": "Budgets",
@@ -444,7 +453,16 @@
       }
     }
   ],
-  "overview_mcp_attention": "{count} servers need attention",
+  "overview_mcp_attention": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} server needs attention",
+        "count_plural=*": "{count} servers need attention"
+      }
+    }
+  ],
   "overview_mcp_connected": "{connected} of {total} servers connected",
   "overview_calendar_cost_year": "${total} in the last year",
   "overview_calendar_tokens_year": "{total} tokens in the last year",
@@ -660,7 +678,16 @@
   "api_keys_show_inactive": "Show inactive",
   "api_keys_path_filter_clear": "Clear the user path filter",
   "api_keys_no_match": "No API keys match the current filter.",
-  "api_keys_hidden": "{count} inactive keys are hidden.",
+  "api_keys_hidden": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} inactive key is hidden.",
+        "count_plural=*": "{count} inactive keys are hidden."
+      }
+    }
+  ],
   "api_keys_empty": "No API keys yet. Issue a key to get started.",
   "api_keys_editor": "API key editor",
   "api_keys_done": "Done, I’ve stored it",
@@ -747,7 +774,16 @@
   "workflows_filter_label": "Filter workflows",
   "workflows_empty": "No active workflows found.",
   "workflows_no_match": "No workflows match your filter.",
-  "workflows_active_scopes": "{count} active scopes",
+  "workflows_active_scopes": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} active scope",
+        "count_plural=*": "{count} active scopes"
+      }
+    }
+  ],
   "workflows_copy_id": "Copy workflow ID",
   "workflows_id_copied": "Workflow ID copied",
   "workflows_copy_id_failed": "Unable to copy workflow ID",
@@ -1065,7 +1101,16 @@
   "api_keys_effective_models_help": "What a request with this key can actually call: its user path's policies, its own allowed models, and model-side policies combined.",
   "api_keys_effective_all": "All models",
   "api_keys_effective_none": "None",
-  "api_keys_effective_count": "{count} models",
+  "api_keys_effective_count": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} model",
+        "count_plural=*": "{count} models"
+      }
+    }
+  ],
   "api_keys_allowed_models_all": "All",
   "api_keys_edit_allowed_models": "Edit Allowed Models",
   "api_keys_allowed_models_editor": "API key allowed models editor",
@@ -1094,7 +1139,16 @@
   "users_column_effective": "Effective models",
   "users_effective_all": "All models",
   "users_effective_none": "None",
-  "users_effective_count": "{count} models",
+  "users_effective_count": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} model",
+        "count_plural=*": "{count} models"
+      }
+    }
+  ],
   "users_effective_via": "via {path}",
   "users_no_models_warning": "No models would remain available: nothing in this list is allowed by the parent groups.",
   "users_column_keys": "API keys",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -1085,7 +1085,18 @@
   "api_keys_effective_models_help": "Co Request z tym kluczem może faktycznie wywołać: polityki jego User Path, jego własne dozwolone modele i polityki po stronie modeli razem.",
   "api_keys_effective_all": "Wszystkie modele",
   "api_keys_effective_none": "Brak",
-  "api_keys_effective_count": "{count} modeli",
+  "api_keys_effective_count": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} model",
+        "count_plural=few": "{count} modele",
+        "count_plural=many": "{count} modeli",
+        "count_plural=*": "{count} modelu"
+      }
+    }
+  ],
   "api_keys_allowed_models_all": "Wszystkie",
   "api_keys_edit_allowed_models": "Edytuj dozwolone modele",
   "api_keys_allowed_models_editor": "Edytor dozwolonych modeli klucza API",
@@ -1114,7 +1125,18 @@
   "users_column_effective": "Efektywne modele",
   "users_effective_all": "Wszystkie modele",
   "users_effective_none": "Brak",
-  "users_effective_count": "{count} modeli",
+  "users_effective_count": [
+    {
+      "declarations": ["input count", "local count_plural = count: plural"],
+      "selectors": ["count_plural"],
+      "match": {
+        "count_plural=one": "{count} model",
+        "count_plural=few": "{count} modele",
+        "count_plural=many": "{count} modeli",
+        "count_plural=*": "{count} modelu"
+      }
+    }
+  ],
   "users_effective_via": "przez {path}",
   "users_no_models_warning": "Żaden model nie pozostałby dostępny: nic z tej listy nie jest dozwolone przez grupy nadrzędne.",
   "users_column_keys": "Klucze API",

--- a/web/dashboard/src/pages/workflows/WorkflowChart.svelte
+++ b/web/dashboard/src/pages/workflows/WorkflowChart.svelte
@@ -78,7 +78,10 @@
     <span class="workflow-node-badge">{badge}</span>
   {/if}
   {#if status}
-    <span class="workflow-node-badge">{status}</span>
+    <!-- A verdict badge carries a guardrail code, which can be long enough to
+         push the Response node out of the row; it truncates and keeps the full
+         text in its tooltip. -->
+    <span class="workflow-node-badge workflow-node-status" title={status}>{status}</span>
   {/if}
   {#if sub}
     <span class="workflow-node-sub">{sub}</span>
@@ -393,6 +396,13 @@
     background: var(--bg);
     color: var(--text-muted);
     line-height: 1.5;
+  }
+
+  .workflow-node-status {
+    max-width: 132px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
   }
 
   /* ─── Endpoint nodes (Client / Response) ─── */

--- a/web/dashboard/src/styles/tables.css
+++ b/web/dashboard/src/styles/tables.css
@@ -17,7 +17,7 @@
   justify-content: flex-end;
 }
 
-input:is([type="text"], [type="date"], [type="number"]) {
+input:is([type="text"], [type="password"], [type="date"], [type="number"]) {
   width: 100%;
   padding: 8px 12px;
   background: var(--bg-surface);
@@ -29,7 +29,7 @@ input:is([type="text"], [type="date"], [type="number"]) {
   outline: none;
 }
 
-input:is([type="text"], [type="date"], [type="number"]):focus {
+input:is([type="text"], [type="password"], [type="date"], [type="number"]):focus {
   border-color: var(--accent);
 }
 
@@ -37,7 +37,7 @@ input:is([type="text"], [type="date"], [type="number"]):focus {
    field (e.g. an immutable name, or a value owned by config.yaml/env) reads
    as disabled consistently everywhere instead of looking identical to an
    editable one. */
-input:is([type="text"], [type="date"], [type="number"]):disabled,
+input:is([type="text"], [type="password"], [type="date"], [type="number"]):disabled,
 textarea:disabled,
 .form-input:disabled {
   opacity: 0.6;

--- a/web/dashboard/tests/i18n.test.js
+++ b/web/dashboard/tests/i18n.test.js
@@ -41,6 +41,17 @@ test("Paraglide compiles interpolation and locale-aware plurals", () => {
   assert.equal(m.date_picker_last_days({ count: 1 }), "Last 1 day");
   assert.equal(m.date_picker_last_days({ count: 14 }), "Last 14 days");
   assert.equal(m.date_picker_days({ count: 1 }), "1 day");
+  assert.equal(m.workflows_active_scopes({ count: 1 }), "1 active scope");
+  assert.equal(m.workflows_active_scopes({ count: 2 }), "2 active scopes");
+  assert.equal(m.api_keys_effective_count({ count: 1 }), "1 model");
+  assert.equal(m.api_keys_effective_count({ count: 3 }), "3 models");
+  assert.equal(m.users_effective_count({ count: 1 }), "1 model");
+  assert.equal(m.api_keys_hidden({ count: 1 }), "1 inactive key is hidden.");
+  assert.equal(m.api_keys_hidden({ count: 2 }), "2 inactive keys are hidden.");
+  assert.equal(m.overview_mcp_attention({ count: 1 }), "1 server needs attention");
+  assert.equal(m.overview_mcp_attention({ count: 2 }), "2 servers need attention");
+  assert.equal(m.playground_meta_events({ count: 1 }), "1 stream event");
+  assert.equal(m.playground_meta_events({ count: 7 }), "7 stream events");
   assert.equal(
     m.pagination_summary(
       { start: 1, end: 25, total: 80 },
@@ -125,6 +136,18 @@ test("Paraglide compiles interpolation and locale-aware plurals", () => {
   );
   assert.equal(
     m.providers_models_count({ count: 5 }, { locale: "pl" }),
+    "5 modeli",
+  );
+  assert.equal(
+    m.api_keys_effective_count({ count: 1 }, { locale: "pl" }),
+    "1 model",
+  );
+  assert.equal(
+    m.api_keys_effective_count({ count: 2 }, { locale: "pl" }),
+    "2 modele",
+  );
+  assert.equal(
+    m.users_effective_count({ count: 5 }, { locale: "pl" }),
     "5 modeli",
   );
   assert.equal(
@@ -216,6 +239,22 @@ test("Paraglide compiles German interpolation and locale-aware plurals", () => {
     "5 Modelle",
   );
   assert.equal(m.models_count({ count: 5 }, { locale: "de" }), "5 Modelle");
+  assert.equal(
+    m.workflows_active_scopes({ count: 1 }, { locale: "de" }),
+    "1 aktiver Geltungsbereich",
+  );
+  assert.equal(
+    m.workflows_active_scopes({ count: 2 }, { locale: "de" }),
+    "2 aktive Geltungsbereiche",
+  );
+  assert.equal(
+    m.api_keys_hidden({ count: 1 }, { locale: "de" }),
+    "1 inaktiver Schlüssel ist ausgeblendet.",
+  );
+  assert.equal(
+    m.overview_mcp_attention({ count: 1 }, { locale: "de" }),
+    "1 Server braucht Aufmerksamkeit",
+  );
   assert.equal(
     m.models_alias_count({ count: 5 }, { locale: "de" }),
     "5 Aliase",


### PR DESCRIPTION
Dashboard cosmetics and guardrail documentation gaps found in pre-release testing.

**Dashboard**
- Counted strings now use the Paraglide plural selector in `en`/`de` (and `pl` where the noun inflects): active scopes, effective model counts, hidden inactive keys, MCP servers needing attention, stream events. No more "1 active scopes" / "1 aktive Geltungsbereiche".
- `input[type="password"]` (the Presidio `api_key` field, any secret schema field) now gets the same styling as text/date/number inputs instead of the browser default.
- A guardrail verdict badge in the workflow chart truncates with an ellipsis and keeps the full text in its tooltip, so a long code such as `BLOCKED · STRING_REPLACE_MATCH` no longer pushes the Response node out of the row.

**Guardrails (`string_replace`)**
- A `warn` outcome no longer borrows the block-phrased default message: `message` falls back to `Request blocked by policy` only for `block` and `respond`, and the schema field no longer carries that default, so an instance created in the dashboard does not store it. Warn records a note only when one is configured; `block`/`respond` behaviour is unchanged.

**Docs**
- `guardrails.mdx`: stream-phase guardrails run on streamed requests only — a Presidio `restore` setup needs a response-phase instance to cover non-streaming requests, otherwise clients get raw `<PERSON_1>` placeholders.
- Note that `LOGGING_LOG_BODIES` defaults to `true`, so audit `request_body`/`response_body` keep the values Presidio hides from the provider (only the revision body is anonymized).
- "Redact In Flight" example updated to `sk-[A-Za-z0-9_-]{20,}` (current keys contain `-`) with `stream_lookbehind: 256`, plus a note that anything past the lookbehind reaches the client unmasked.
- Presidio tip: `PERSON` spans can swallow an adjacent all-caps token, so a presidio step ahead of `string_replace` can hide the words a later rule looks for.

**Testing**
- `make test-dashboard` (669 pass, including new i18n plural assertions), `npm run check`, `make lint`, `go test ./...`.
- Live gateway with SQLite + gemini: verified the warn outcome now records no message, a stream-phase-only instance leaves non-streaming responses untouched while a response-phase one covers both, audit `request_body` keeps the original text while `request_revisions` holds the rewritten body, and `sk-proj-…` keys leak past a 64-character lookbehind but not at 256. Dashboard checked in a headless browser: secret field now 34px with the shared padding/border, chart badge truncated and Response node back in view.
- `internal/server` `TestVersionEndpointChecksOnFirstVisit`/`RechecksOnANewDay` fail locally before and after this change: the visit cookie uses UTC while the test compares the local date, so they fail in CEST between midnight and 02:00. Untouched by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Warning actions no longer display an unintended default enforcement message.
  - Guardrail documentation now clarifies streaming scope, secret lookbehind settings, and audit-log privacy considerations.

- **User Interface**
  - Dashboard messages now use accurate singular and plural forms across supported languages.
  - Workflow status badges truncate long labels while providing the full text on hover.
  - Password fields now match the styling of other table controls.

- **Documentation**
  - Updated plugin examples to recognize secrets containing underscores and hyphens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->