### PR TITLE
feat(models): add GET /v1/models/{model} retrieve endpoint

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -6264,6 +6264,57 @@ const docTemplate = `{
                 ]
             }
         },
+        "/v1/models/{model}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "models"
+                ],
+                "summary": "Retrieve a model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID, e.g. openai/gpt-4.1-mini",
+                        "name": "model",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/core.Model"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.OpenAIErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/core.OpenAIErrorEnvelope"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/core.OpenAIErrorEnvelope"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/v1/realtime": {
             "get": {
                 "description": "Upgrades to a websocket and relays an OpenAI-compatible realtime (speech-to-speech) session to the provider that owns the model named in the ?model= query parameter. Provider credentials are injected by the gateway. Passing ?call_id= instead attaches to an existing WebRTC/SIP call as a sideband channel; calls created through this gateway instance are routed automatically, others need explicit model (and provider) parameters.",
@@ -8891,6 +8942,60 @@ const docTemplate = `{
                 }
             }
         },
+        "auditlog.GuardrailOutcomeSnapshot": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "Action is the decision (allow, warn, block, respond) or \"failure\" when\nthe instance errored; FailMode then says whether the chain carried on\n(\"open\") or the request failed (\"closed\").",
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "detail": {},
+                "dropped_events": {
+                    "type": "integer"
+                },
+                "duration_ns": {
+                    "type": "integer"
+                },
+                "edited": {
+                    "description": "Edited reports that the instance changed the request (prompt phase)\nor the response (response and stream phases); Target names which.",
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "fail_mode": {
+                    "type": "string"
+                },
+                "instance": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "replaced_events": {
+                    "description": "ReplacedEvents and DroppedEvents count the stream events an in-flight\nstream instance rewrote or withheld.",
+                    "type": "integer"
+                },
+                "seq": {
+                    "type": "integer"
+                },
+                "step": {
+                    "type": "integer"
+                },
+                "target": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "auditlog.LogData": {
             "type": "object",
             "properties": {
@@ -8926,6 +9031,13 @@ const docTemplate = `{
                             "$ref": "#/definitions/auditlog.FailoverSnapshot"
                         }
                     ]
+                },
+                "guardrails": {
+                    "description": "Guardrails records the outcome of every guardrail (plugin instance)\nthat ran for the request, in execution order across the prompt,\nresponse and stream phases: what each decided, whether it edited the\nrequest or response, and how it failed. It is the decision trail;\nRequestRevisions is the body trail. A configured step without an\noutcome did not run (an earlier block, a cache hit).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/auditlog.GuardrailOutcomeSnapshot"
+                    }
                 },
                 "labels": {
                     "description": "Labels are request labels extracted from configured tagging headers.",

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -51,6 +51,7 @@ Anthropic unchanged.
 | `POST /v1/messages` | Creates a message through translated model routing. Supports streaming (`stream: true`) with Anthropic-format SSE events. |
 | `POST /v1/messages/count_tokens` | Counts input tokens. Exact for models whose provider has a counting endpoint (Anthropic); a calibrated estimate otherwise. |
 | `GET /v1/models` | Returns the catalog in the Anthropic list shape (`type: "model"`, `display_name`, `created_at`) when the request carries the `anthropic-version` header the Anthropic SDKs always send; OpenAI shape otherwise. |
+| `GET /v1/models/{model}` | Retrieves one model, in the Anthropic model shape when the request carries `anthropic-version`; OpenAI shape otherwise. |
 | `POST /v1/messages/batches` | Creates a Message Batch. Inline `requests[].params` are translated per item, so a batch can target any provider with native batch support (Anthropic, OpenAI, …), not only Anthropic. |
 | `GET /v1/messages/batches` | Lists batches (`limit`, `after_id`). |
 | `GET /v1/messages/batches/{id}` | Retrieves a batch (`processing_status`, `request_counts`, `results_url` once ended). |

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -37,6 +37,7 @@ For request and response details, see the dedicated guides:
 | `/v1/conversations/{id}/items/{item_id}` | DELETE | Delete a conversation item and return the conversation                                                |
 | `/v1/embeddings`                  | POST   | Text embeddings                                                                                              |
 | `/v1/models`                      | GET    | List available models                                                                                        |
+| `/v1/models/{model}`              | GET    | Retrieve one model by ID (`openai/gpt-4.1-mini`; slashes may be sent raw or percent-encoded)                  |
 | `/v1/audio/speech`                | POST   | Text-to-speech, returning binary audio                                                                       |
 | `/v1/audio/transcriptions`        | POST   | Speech-to-text from a multipart upload                                                                       |
 | `/v1/images/generations`          | POST   | Image generation from a text prompt (DALL·E, gpt-image-1, grok-2-image, Imagen, Gemini image models)                                     |

--- a/docs/advanced/model-metadata.mdx
+++ b/docs/advanced/model-metadata.mdx
@@ -61,8 +61,9 @@ flowchart LR
 - **Modes and categories** drive dashboard grouping only — routing never
   blocks on them, so `/v1/embeddings` reaches any model
   the provider serves.
-- **Context window and capabilities** are advertised on `GET /v1/models` for
-  clients that pick models dynamically.
+- **Context window and capabilities** are advertised on `GET /v1/models` (and
+  on `GET /v1/models/{model}` for a single model) for clients that pick models
+  dynamically.
 
 ## Offline behavior
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9389,6 +9389,79 @@
         }
       }
     },
+    "/v1/models/{model}": {
+      "get": {
+        "tags": [
+          "models"
+        ],
+        "summary": "Retrieve a model",
+        "parameters": [
+          {
+            "description": "Model ID, e.g. openai/gpt-4.1-mini",
+            "name": "model",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.Model"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.OpenAIErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.OpenAIErrorEnvelope"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.OpenAIErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/models/{model}",
+            "title": "Retrieve a model",
+            "description": "GoModel API reference for GET /v1/models/{model}: Retrieve a model."
+          }
+        }
+      }
+    },
     "/v1/realtime": {
       "get": {
         "description": "Upgrades to a websocket and relays an OpenAI-compatible realtime (speech-to-speech) session to the provider that owns the model named in the ?model= query parameter. Provider credentials are injected by the gateway. Passing ?call_id= instead attaches to an existing WebRTC/SIP call as a sideband channel; calls created through this gateway instance are routed automatically, others need explicit model (and provider) parameters.",

--- a/internal/anthropicapi/models.go
+++ b/internal/anthropicapi/models.go
@@ -28,18 +28,24 @@ type ModelInfo struct {
 func FromModels(models []core.Model) *ModelsList {
 	out := &ModelsList{Data: make([]ModelInfo, 0, len(models))}
 	for _, model := range models {
-		out.Data = append(out.Data, ModelInfo{
-			Type:        "model",
-			ID:          model.ID,
-			DisplayName: modelDisplayName(model),
-			CreatedAt:   time.Unix(model.Created, 0).UTC().Format(time.RFC3339),
-		})
+		out.Data = append(out.Data, FromModel(model))
 	}
 	if len(out.Data) > 0 {
 		out.FirstID = &out.Data[0].ID
 		out.LastID = &out.Data[len(out.Data)-1].ID
 	}
 	return out
+}
+
+// FromModel renders one model in the Anthropic model shape, as returned by
+// Anthropic's retrieve-model endpoint.
+func FromModel(model core.Model) ModelInfo {
+	return ModelInfo{
+		Type:        "model",
+		ID:          model.ID,
+		DisplayName: modelDisplayName(model),
+		CreatedAt:   time.Unix(model.Created, 0).UTC().Format(time.RFC3339),
+	}
 }
 
 func modelDisplayName(model core.Model) string {

--- a/internal/server/handlers_inference.go
+++ b/internal/server/handlers_inference.go
@@ -59,59 +59,9 @@ func (h *Handler) ListModels(c *echo.Context) error {
 		return err
 	}
 
-	// Create context with request ID for provider
-	requestID := c.Request().Header.Get(core.RequestIDHeader)
-	ctx := core.WithRequestID(c.Request().Context(), requestID)
-
-	resp, err := h.provider.ListModels(ctx)
+	resp, err := h.visibleModels(c)
 	if err != nil {
 		return handleError(c, err)
-	}
-	if h.keepOnlyAliasesAtModelsEndpoint {
-		object := "list"
-		if resp != nil && resp.Object != "" {
-			object = resp.Object
-		}
-		resp = &core.ModelsResponse{Object: object, Data: []core.Model{}}
-	}
-	if h.modelAuthorizer != nil && resp != nil {
-		resp = &core.ModelsResponse{
-			Object: resp.Object,
-			Data:   h.modelAuthorizer.FilterPublicModels(c.Request().Context(), resp.Data),
-		}
-	}
-	if h.exposedModelLister != nil {
-		ctx := c.Request().Context()
-		// The target-access filter is only available when an authorizer is set.
-		var allow func(core.ModelSelector) bool
-		if h.modelAuthorizer != nil {
-			allow = func(selector core.ModelSelector) bool {
-				return h.modelAuthorizer.AllowsModel(ctx, selector)
-			}
-		}
-		// User-path scoping of redirects is a property of the redirect itself, not
-		// of the authorizer, so it must apply even when no authorizer is configured
-		// (allow is nil there) — otherwise scoped redirect IDs leak to callers
-		// outside their user_paths.
-		if scoped, ok := h.exposedModelLister.(UserPathExposedModelLister); ok {
-			resp = mergeExposedModelsResponse(resp, scoped.ExposedModelsForUserPath(core.UserPathFromContext(ctx), allow))
-		} else if filtered, ok := h.exposedModelLister.(FilteredExposedModelLister); ok && allow != nil {
-			resp = mergeExposedModelsResponse(resp, filtered.ExposedModelsFiltered(allow))
-		} else {
-			exposed := h.exposedModelLister.ExposedModels()
-			if allow != nil {
-				filtered := make([]core.Model, 0, len(exposed))
-				for _, model := range exposed {
-					selector, err := core.ParseModelSelector(model.ID, "")
-					if err != nil || !allow(selector) {
-						continue
-					}
-					filtered = append(filtered, model)
-				}
-				exposed = filtered
-			}
-			resp = mergeExposedModelsResponse(resp, exposed)
-		}
 	}
 
 	// The models route is shared by both wire dialects. Anthropic SDK clients

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -431,6 +431,10 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		e.OPTIONS("/p/:provider/*", handler.ProviderPassthrough)
 	}
 	e.GET("/v1/models", handler.ListModels)
+	// Model IDs carry the provider prefix and may contain several slashes, so
+	// retrieve is a wildcard route; it only matches under /v1/models/ and
+	// therefore shadows no other /v1 route.
+	e.GET("/v1/models/*", handler.RetrieveModel)
 	e.GET("/v1/usage", handler.UsageStatus)
 	// Opt-in: the route answers questions about credentials, so it is only
 	// mounted where an operator asked for it.

--- a/internal/server/models_endpoint.go
+++ b/internal/server/models_endpoint.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/anthropicapi"
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// visibleModels builds the model catalog this caller is allowed to see: the
+// provider catalog (unless only aliases are exposed), filtered by the key's
+// model policy, merged with the virtual models in scope for the request's user
+// path. Both GET /v1/models and GET /v1/models/{model} answer from it, so a
+// retrieve can never surface a model the list would have hidden.
+func (h *Handler) visibleModels(c *echo.Context) (*core.ModelsResponse, error) {
+	// Create context with request ID for provider
+	requestID := c.Request().Header.Get(core.RequestIDHeader)
+	ctx := core.WithRequestID(c.Request().Context(), requestID)
+
+	resp, err := h.provider.ListModels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if h.keepOnlyAliasesAtModelsEndpoint {
+		object := "list"
+		if resp != nil && resp.Object != "" {
+			object = resp.Object
+		}
+		resp = &core.ModelsResponse{Object: object, Data: []core.Model{}}
+	}
+	if h.modelAuthorizer != nil && resp != nil {
+		resp = &core.ModelsResponse{
+			Object: resp.Object,
+			Data:   h.modelAuthorizer.FilterPublicModels(c.Request().Context(), resp.Data),
+		}
+	}
+	if h.exposedModelLister != nil {
+		ctx := c.Request().Context()
+		// The target-access filter is only available when an authorizer is set.
+		var allow func(core.ModelSelector) bool
+		if h.modelAuthorizer != nil {
+			allow = func(selector core.ModelSelector) bool {
+				return h.modelAuthorizer.AllowsModel(ctx, selector)
+			}
+		}
+		// User-path scoping of redirects is a property of the redirect itself, not
+		// of the authorizer, so it must apply even when no authorizer is configured
+		// (allow is nil there) — otherwise scoped redirect IDs leak to callers
+		// outside their user_paths.
+		if scoped, ok := h.exposedModelLister.(UserPathExposedModelLister); ok {
+			resp = mergeExposedModelsResponse(resp, scoped.ExposedModelsForUserPath(core.UserPathFromContext(ctx), allow))
+		} else if filtered, ok := h.exposedModelLister.(FilteredExposedModelLister); ok && allow != nil {
+			resp = mergeExposedModelsResponse(resp, filtered.ExposedModelsFiltered(allow))
+		} else {
+			exposed := h.exposedModelLister.ExposedModels()
+			if allow != nil {
+				kept := make([]core.Model, 0, len(exposed))
+				for _, model := range exposed {
+					selector, err := core.ParseModelSelector(model.ID, "")
+					if err != nil || !allow(selector) {
+						continue
+					}
+					kept = append(kept, model)
+				}
+				exposed = kept
+			}
+			resp = mergeExposedModelsResponse(resp, exposed)
+		}
+	}
+	return resp, nil
+}
+
+// RetrieveModel handles GET /v1/models/{model}
+//
+// Model IDs carry the provider prefix and may contain several slashes
+// (groq/openai/gpt-oss-20b, fireworks/accounts/fireworks/models/glm-5p3-flash),
+// so the route is a wildcard and the ID is the whole remainder of the path,
+// raw or percent-encoded.
+//
+// @Summary      Retrieve a model
+// @Tags         models
+// @Produce      json
+// @Security     BearerAuth
+// @Param        model  path      string  true  "Model ID, e.g. openai/gpt-4.1-mini"
+// @Success      200    {object}  core.Model
+// @Failure      401    {object}  core.OpenAIErrorEnvelope
+// @Failure      404    {object}  core.OpenAIErrorEnvelope
+// @Failure      502    {object}  core.OpenAIErrorEnvelope
+// @Router       /v1/models/{model} [get]
+func (h *Handler) RetrieveModel(c *echo.Context) error {
+	modelID := retrieveModelID(c)
+	if modelID == "" {
+		// "/v1/models/" names no model; answer it as the list rather than as a
+		// 404 for the empty model ID.
+		return h.ListModels(c)
+	}
+
+	// Same user-path handling as the list endpoint, so both apply the same
+	// visibility policy.
+	if ok, err := applyUserPathHeaderToContext(c); !ok {
+		return err
+	}
+
+	resp, err := h.visibleModels(c)
+	if err != nil {
+		return handleError(c, err)
+	}
+
+	var models []core.Model
+	if resp != nil {
+		models = resp.Data
+	}
+	for _, model := range models {
+		if model.ID != modelID {
+			continue
+		}
+		// The models routes are shared by both wire dialects; Anthropic SDK
+		// clients are identified by the anthropic-version header they always
+		// send (see ListModels).
+		if c.Request().Header.Get("anthropic-version") != "" {
+			return c.JSON(http.StatusOK, anthropicapi.FromModel(model))
+		}
+		if model.Object == "" {
+			model.Object = "model"
+		}
+		return c.JSON(http.StatusOK, model)
+	}
+
+	notFound := core.NewModelNotFoundError(modelID)
+	if c.Request().Header.Get("anthropic-version") != "" {
+		status, body := anthropicapi.ErrorFromGateway(notFound)
+		return c.JSON(status, body)
+	}
+	return handleError(c, notFound)
+}
+
+// retrieveModelID reads the model ID from the wildcard segment of
+// /v1/models/*. Echo hands path params back percent-encoded, so an ID sent as
+// openai%2Fgpt-4.1-mini resolves to the same model as openai/gpt-4.1-mini.
+func retrieveModelID(c *echo.Context) string {
+	raw := strings.TrimPrefix(c.Param("*"), "/")
+	if raw == "" {
+		return ""
+	}
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		return decoded
+	}
+	return raw
+}

--- a/internal/server/models_endpoint_test.go
+++ b/internal/server/models_endpoint_test.go
@@ -1,0 +1,225 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/virtualmodels"
+)
+
+func retrieveModelCatalog() *core.ModelsResponse {
+	return &core.ModelsResponse{
+		Object: "list",
+		Data: []core.Model{
+			{
+				ID:       "openai/gpt-4.1-mini",
+				Object:   "model",
+				Created:  1721172741,
+				OwnedBy:  "openai",
+				Metadata: &core.ModelMetadata{DisplayName: "GPT-4.1 mini"},
+			},
+			{ID: "groq/openai/gpt-oss-20b", Object: "model", Created: 1712361441, OwnedBy: "groq"},
+			{
+				ID:      "fireworks/accounts/fireworks/models/glm-5p3-flash",
+				Object:  "model",
+				Created: 1712361441,
+				OwnedBy: "fireworks",
+			},
+		},
+	}
+}
+
+func TestRetrieveModel(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantID     string
+		wantBody   []string
+	}{
+		{
+			name:       "plain provider-qualified id",
+			path:       "/v1/models/openai/gpt-4.1-mini",
+			wantStatus: http.StatusOK,
+			wantID:     "openai/gpt-4.1-mini",
+			wantBody:   []string{`"object":"model"`, `"owned_by":"openai"`, `"display_name":"GPT-4.1 mini"`},
+		},
+		{
+			name:       "id with two slashes",
+			path:       "/v1/models/groq/openai/gpt-oss-20b",
+			wantStatus: http.StatusOK,
+			wantID:     "groq/openai/gpt-oss-20b",
+		},
+		{
+			name:       "long provider id",
+			path:       "/v1/models/fireworks/accounts/fireworks/models/glm-5p3-flash",
+			wantStatus: http.StatusOK,
+			wantID:     "fireworks/accounts/fireworks/models/glm-5p3-flash",
+		},
+		{
+			name:       "percent-encoded slashes",
+			path:       "/v1/models/openai%2Fgpt-4.1-mini",
+			wantStatus: http.StatusOK,
+			wantID:     "openai/gpt-4.1-mini",
+		},
+		{
+			name:       "unknown id",
+			path:       "/v1/models/openai/does-not-exist",
+			wantStatus: http.StatusNotFound,
+			wantBody:   []string{`"code":"model_not_found"`, "openai/does-not-exist"},
+		},
+		{
+			name:       "empty id falls back to the list route",
+			path:       "/v1/models/",
+			wantStatus: http.StatusOK,
+			wantBody:   []string{`"object":"list"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := New(&mockProvider{modelsResponse: retrieveModelCatalog()}, &Config{})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code, rec.Body.String())
+			if tt.wantID != "" {
+				var model core.Model
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &model))
+				require.Equal(t, tt.wantID, model.ID)
+				require.Equal(t, "model", model.Object)
+			}
+			for _, want := range tt.wantBody {
+				require.Contains(t, rec.Body.String(), want)
+			}
+		})
+	}
+}
+
+func TestRetrieveModel_MatchesListEntry(t *testing.T) {
+	srv := New(&mockProvider{modelsResponse: retrieveModelCatalog()}, &Config{})
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	var list core.ModelsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.NotEmpty(t, list.Data)
+
+	for _, listed := range list.Data {
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models/"+listed.ID, nil))
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+		var retrieved core.Model
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &retrieved))
+		require.Equal(t, listed, retrieved)
+	}
+}
+
+func TestRetrieveModel_HiddenModelsReturn404(t *testing.T) {
+	mock := &mockProvider{
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data:   []core.Model{{ID: "openai/gpt-4.1-mini", Object: "model", OwnedBy: "openai"}},
+		},
+	}
+	authorizer := &userPathModelAuthorizer{allowedUnder: map[string]string{"/acme/eng": "anthropic"}}
+	srv := New(mock, &Config{
+		ModelAuthorizer: authorizer,
+		ExposedModelLister: staticExposedModelLister{
+			models: []core.Model{{ID: "anthropic/claude-haiku-4-5", Object: "model", OwnedBy: "anthropic"}},
+		},
+	})
+
+	get := func(id, userPath string) int {
+		req := httptest.NewRequest(http.MethodGet, "/v1/models/"+id, nil)
+		if userPath != "" {
+			req.Header.Set(core.UserPathHeader, userPath)
+		}
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	require.Equal(t, http.StatusOK, get("openai/gpt-4.1-mini", ""))
+	// Under /acme/eng only anthropic models are visible, so the OpenAI model
+	// must 404 rather than leak its metadata.
+	require.Equal(t, http.StatusNotFound, get("openai/gpt-4.1-mini", "/acme/eng/alice"))
+	require.Equal(t, http.StatusOK, get("anthropic/claude-haiku-4-5", "/acme/eng/alice"))
+}
+
+func TestRetrieveModel_VirtualModels(t *testing.T) {
+	catalog := &aliasesTestCatalog{
+		supported:     map[string]bool{"openai/gpt-4o": true},
+		providerTypes: map[string]string{"openai/gpt-4o": "openai"},
+		models:        map[string]core.Model{"openai/gpt-4o": {ID: "gpt-4o", Object: "model", OwnedBy: "openai"}},
+	}
+	service, err := virtualmodels.NewService(newAliasesTestStore(
+		redirectVM("smart", "gpt-4o", "openai", true),
+	), catalog, true)
+	require.NoError(t, err)
+	require.NoError(t, service.Refresh(context.Background()))
+
+	mock := &mockProvider{
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data:   []core.Model{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}},
+		},
+	}
+	srv := New(mock, &Config{
+		ExposedModelLister:              service,
+		KeepOnlyAliasesAtModelsEndpoint: true,
+	})
+
+	get := func(id string) int {
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models/"+id, nil))
+		return rec.Code
+	}
+
+	require.Equal(t, http.StatusOK, get("smart"))
+	// keep_only_aliases_at_models_endpoint hides concrete provider models from
+	// the list, so retrieve must hide them too.
+	require.Equal(t, http.StatusNotFound, get("gpt-4o"))
+}
+
+func TestRetrieveModel_AnthropicDialect(t *testing.T) {
+	srv := New(&mockProvider{modelsResponse: retrieveModelCatalog()}, &Config{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/openai/gpt-4.1-mini", nil)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	body := rec.Body.String()
+	require.Contains(t, body, `"type":"model"`)
+	require.Contains(t, body, `"id":"openai/gpt-4.1-mini"`)
+	require.Contains(t, body, `"display_name":"GPT-4.1 mini"`)
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/models/openai/nope", nil)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), `"type":"error"`)
+}
+
+func TestRetrieveModel_ProviderErrorIsReported(t *testing.T) {
+	srv := New(&mockProvider{err: context.DeadlineExceeded}, &Config{})
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models/openai/gpt-4.1-mini", nil))
+
+	require.NotEqual(t, http.StatusNotFound, rec.Code)
+	require.GreaterOrEqual(t, rec.Code, http.StatusInternalServerError)
+}


### PR DESCRIPTION
Adds the OpenAI-compatible retrieve-model endpoint, so `client.models.retrieve("openai/gpt-4.1-mini")` works instead of returning `unknown API endpoint`.

- `GET /v1/models/{model}` returns the same object a `GET /v1/models` entry carries (id, `object: "model"`, created, owned_by, GoModel metadata), so clients can use them interchangeably.
- Both routes answer from one shared catalog builder, so visibility rules are identical: per-key/user-path model policy, user-path-scoped virtual models, `keep_only_aliases_at_models_endpoint`, aliases. A model the list hides returns 404 `model_not_found` rather than leaking metadata.
- The route is a wildcard because model IDs contain slashes (`groq/openai/gpt-oss-20b`, `fireworks/accounts/fireworks/models/glm-5p3-flash`); percent-encoded slashes resolve the same. It only matches under `/v1/models/`, so no other `/v1` route is shadowed. `/v1/models/` (empty ID) answers as the list.
- Anthropic SDK clients (requests carrying `anthropic-version`) get the Anthropic single-model shape, and Anthropic-shaped errors, matching what `GET /v1/models` already does for the list.

Docs: `docs/advanced/api-endpoints.mdx`, `model-metadata.mdx`, `anthropic-messages-api.mdx`, regenerated `docs/openapi.json` / swagger docs.

Tested: new table-driven handler tests next to the existing `/v1/models` tests (plain, two-slash, long fireworks, encoded, unknown, hidden-by-policy, virtual model, Anthropic dialect); `go build ./...`, `go test -race ./internal/server ./internal/anthropicapi`, `make lint`. Live against a local gateway with real providers: curl for each ID shape plus a restricted user path, and the OpenAI Python SDK `models.retrieve` for openai/groq/fireworks IDs, a virtual model, and a 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to retrieve details for a single model by ID.
  - Supports provider-qualified and percent-encoded model IDs.
  - Returns model details in OpenAI or Anthropic format based on the request.
  - Applies existing visibility, authorization, alias, and user-path rules to individual model retrieval.
  - Model metadata such as context limits and capabilities is now available for individual models.

- **Documentation**
  - Documented the new model retrieval endpoint and response formats.
  - Updated API specifications and audit log schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->