### PR TITLE
docs(cache): document cache_mode and uncached failover responses

### DIFF
--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -347,7 +347,9 @@ curl "http://localhost:8080/admin/usage/summary?user_path=/team/alpha&cache_mode
 Accepted by `/admin/usage/summary`, `/admin/usage/daily`, `/admin/usage/log`,
 `/admin/usage/models`, `/admin/usage/labels`, `/admin/usage/user-paths`, and
 `/v1/usage` (see the [usage API](/advanced/usage-api#cache-mode)). Unrecognized
-values fall back to `uncached`.
+values fall back to `uncached`. `/admin/usage/sessions` ignores it: session
+request and token totals always include cache hits, while its cost fields stay
+provider-only.
 
 Two endpoints ignore it by design: `/admin/cache/overview` always reports cache
 hits only, and `/admin/usage/sessions` always includes them (its cost fields

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -225,6 +225,7 @@ Returns aggregate token usage statistics over a configurable time window.
 | `start_date` | string | Range start in `YYYY-MM-DD` format                       | 29 days before end   |
 | `end_date`   | string | Range end in `YYYY-MM-DD` format                         | Today                |
 | `days`       | int    | Shorthand for look-back window (ignored if dates are set) | `30`                |
+| `cache_mode` | string | Which requests to count: `uncached`, `cached`, `all` (see [Cache mode](#cache-mode)) | `uncached` |
 
 Use `start_date`/`end_date` for explicit ranges or `days` as a shorthand. When both are provided, `start_date`/`end_date` take priority.
 
@@ -253,6 +254,7 @@ Returns per-period token usage breakdown over a configurable time window, groupe
 | `end_date`   | string | Range end in `YYYY-MM-DD` format                         | Today                |
 | `days`       | int    | Shorthand for look-back window (ignored if dates are set) | `30`                |
 | `interval`   | string | Grouping: `daily`, `weekly`, `monthly`, `yearly`         | `daily`              |
+| `cache_mode` | string | Which requests to count: `uncached`, `cached`, `all` (see [Cache mode](#cache-mode)) | `uncached` |
 
 The `date` field in the response changes format based on the interval: `YYYY-MM-DD` (daily), `YYYY-Www` (weekly), `YYYY-MM` (monthly), or `YYYY` (yearly).
 
@@ -323,6 +325,33 @@ provider-bound requests only, so avoided cache cost is not reported as spend.
   "offset": 0
 }
 ```
+
+### Cache mode
+
+Every [response-cache](/features/cache) hit is recorded as a usage entry, with
+the caller's `user_path` and a `cache_type` of `exact` or `semantic`. The usage
+endpoints leave those entries out by default, so requests, tokens, and cost all
+describe provider spend. Pass `cache_mode` to change that:
+
+| Value      | Counts                                                    |
+| ---------- | --------------------------------------------------------- |
+| `uncached` | Provider-bound requests only — the default                 |
+| `cached`   | Local cache hits only — what the cache served for free     |
+| `all`      | Both, the gateway's total request volume                   |
+
+```bash
+curl "http://localhost:8080/admin/usage/summary?user_path=/team/alpha&cache_mode=all" \
+  -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
+```
+
+Accepted by `/admin/usage/summary`, `/admin/usage/daily`, `/admin/usage/log`,
+`/admin/usage/models`, `/admin/usage/labels`, `/admin/usage/user-paths`, and
+`/v1/usage` (see the [usage API](/advanced/usage-api#cache-mode)). Unrecognized
+values fall back to `uncached`.
+
+Two endpoints ignore it by design: `/admin/cache/overview` always reports cache
+hits only, and `/admin/usage/sessions` always includes them (its cost fields
+stay provider-only).
 
 ### GET /admin/audit/stats
 

--- a/docs/advanced/usage-api.mdx
+++ b/docs/advanced/usage-api.mdx
@@ -249,6 +249,28 @@ console.log(dateRange);
 Budgets and rate limits always report their own live periods; the window only
 affects `usage`.
 
+## Cache mode
+
+The `usage` block counts provider-bound requests only, so it lines up with
+budgets and cost. [Response-cache](/features/cache) hits are recorded too, and
+`cache_mode` brings them into view:
+
+| Value      | Counts                                                  |
+| ---------- | -------------------------------------------------------- |
+| `uncached` | Provider-bound requests only — the default               |
+| `cached`   | Local cache hits only — what the cache served for free   |
+| `all`      | Both, your total request volume                          |
+
+```bash
+curl "http://localhost:8080/v1/usage?cache_mode=cached" \
+  -H "Authorization: Bearer sk_gom_..."
+```
+
+Comparing `cached` with the default is the quickest read on how much of your
+traffic the cache is absorbing. Unrecognized values fall back to `uncached`.
+`cache_mode` affects only `usage`: budgets and rate limits never count cache
+hits, because a hit spends nothing and consumes no quota.
+
 ## Errors
 
 | Status | Meaning                                                                |

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -153,6 +153,22 @@ Common patterns:
 - use different scoped workflows for different `user_path` values
 - include scope-specific context so the final request body differs
 
+## Responses served through failover are not cached
+
+When a request is answered by a [failover](/features/failover) target rather
+than the one routing picked first, the response is not stored. The exact-cache
+key is hashed from the pre-failover resolution, so storing the backup's answer
+would serve it under the primary's key once the primary recovers.
+
+The practical consequence: a virtual model whose first target is chronically
+down gets no cache benefit for as long as it stays down — every request misses,
+fails over, and is served fresh. If a target is going to be unavailable for a
+while, reorder the chain (or point the virtual model at a healthy target) so
+the responses that answer it are cacheable again.
+
+Retries within one target are unaffected: only a response produced after the
+sweep moved to another target is withheld from both cache layers.
+
 ## Cache analytics
 
 When response caching and usage tracking are enabled, the admin API exposes a
@@ -162,5 +178,21 @@ cached-only overview at:
 /admin/cache/overview
 ```
 
-Cached usage entries are also visible in the regular usage log and summary
-endpoints.
+Cache hits are also recorded as usage entries, with the caller's `user_path`
+and a `cache_type` of `exact` or `semantic`. The usage endpoints
+(`/admin/usage/*` and `/v1/usage`) leave them out by default so that totals and
+cost track provider spend; pass `cache_mode=all` to include them, or
+`cache_mode=cached` to see only the hits:
+
+```bash
+# provider-bound requests only (default)
+curl "http://localhost:8080/admin/usage/summary?user_path=/team/alpha" \
+  -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
+
+# including local cache hits
+curl "http://localhost:8080/admin/usage/summary?user_path=/team/alpha&cache_mode=all" \
+  -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
+```
+
+See [admin endpoints](/advanced/admin-endpoints#cache-mode) and the
+[usage API](/advanced/usage-api#cache-mode).

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -161,10 +161,13 @@ key is hashed from the pre-failover resolution, so storing the backup's answer
 would serve it under the primary's key once the primary recovers.
 
 The practical consequence: a virtual model whose first target is chronically
-down gets no cache benefit for as long as it stays down — every request misses,
-fails over, and is served fresh. If a target is going to be unavailable for a
-while, reorder the chain (or point the virtual model at a healthy target) so
-the responses that answer it are cacheable again.
+down stops accumulating cache entries for as long as it stays down — every
+request that misses fails over and is served fresh, and nothing it produces is
+stored. Entries written before the outage keep serving until their TTL expires:
+a lookup runs ahead of dispatch, so a hit is returned without touching either
+target. If a target is going to be unavailable for a while, reorder the chain
+(or point the virtual model at a healthy target) so the responses that answer
+it are cacheable again.
 
 Retries within one target are unaffected: only a response produced after the
 sweep moved to another target is withheld from both cache layers.
@@ -182,7 +185,9 @@ Cache hits are also recorded as usage entries, with the caller's `user_path`
 and a `cache_type` of `exact` or `semantic`. The usage endpoints
 (`/admin/usage/*` and `/v1/usage`) leave them out by default so that totals and
 cost track provider spend; pass `cache_mode=all` to include them, or
-`cache_mode=cached` to see only the hits:
+`cache_mode=cached` to see only the hits. `/admin/usage/sessions` is the
+exception: session request and token totals always include cache hits, while
+its cost fields stay provider-only.
 
 ```bash
 # provider-bound requests only (default)

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -106,7 +106,8 @@ failover to the model rather than replacing it.
   [response cache](/features/cache#responses-served-through-failover-are-not-cached):
   the cache key is hashed from the pre-failover resolution, so the backup's
   answer would otherwise be replayed under the primary's key. While a first
-  target is down, every request to that chain therefore misses the cache.
+  target is down, the chain therefore stops adding cache entries; entries
+  written before the outage still serve until their TTL expires.
 </Note>
 
 Set `FAILOVER_ENABLED=false` (or `failover.enabled: false`) to switch the

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -101,6 +101,14 @@ virtual model that shadows exactly that model and lists it as a target (the
 shape the Models page creates for a real model), since that virtual model adds
 failover to the model rather than replacing it.
 
+<Note>
+  A response produced by a failover target is not written to the
+  [response cache](/features/cache#responses-served-through-failover-are-not-cached):
+  the cache key is hashed from the pre-failover resolution, so the backup's
+  answer would otherwise be replayed under the primary's key. While a first
+  target is down, every request to that chain therefore misses the cache.
+</Note>
+
 Set `FAILOVER_ENABLED=false` (or `failover.enabled: false`) to switch the
 sweep off globally; a [workflow](/advanced/workflows) can also turn it off for
 its scope. The chosen target is still served, without retries.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10930,6 +10930,14 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "description": "Which requests to count: uncached (default, provider-bound only), cached (local response-cache hits only), or all",
+            "name": "cache_mode",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/internal/server/usage_status_handler.go
+++ b/internal/server/usage_status_handler.go
@@ -104,6 +104,7 @@ type usageStatusRateLimit struct {
 // @Param        start_date  query  string  false  "Inclusive window start (YYYY-MM-DD, UTC); defaults to 29 days before end_date"
 // @Param        end_date    query  string  false  "Inclusive window end (YYYY-MM-DD, UTC); defaults to today; the whole range may span at most 365 days"
 // @Param        days        query  int     false  "Window length ending today when no explicit dates are given (default 30, max 365)"
+// @Param        cache_mode  query  string  false  "Which requests to count: uncached (default, provider-bound only), cached (local response-cache hits only), or all"
 // @Success      200  {object}  usageStatusResponse
 // @Failure      400  {object}  core.OpenAIErrorEnvelope
 // @Failure      401  {object}  core.OpenAIErrorEnvelope
@@ -185,9 +186,12 @@ func (h *Handler) usageStatusUserPath(c *echo.Context) (string, error) {
 }
 
 // usageStatusWindow resolves the summary date window from the same query
-// params as the dashboard usage endpoints, always in UTC.
+// params as the dashboard usage endpoints, always in UTC. cache_mode is read
+// here too so a tenant can see its own local response-cache hits, which the
+// default ("uncached", provider-bound requests only) leaves out; unknown
+// values fall back to that default, as on the admin endpoints.
 func usageStatusWindow(c *echo.Context, now time.Time) (usage.UsageQueryParams, error) {
-	params := usage.UsageQueryParams{TimeZone: "UTC"}
+	params := usage.UsageQueryParams{TimeZone: "UTC", CacheMode: strings.TrimSpace(c.QueryParam("cache_mode"))}
 	days := usage.DefaultDateRangeDays
 	if raw := c.QueryParam("days"); raw != "" {
 		parsed, err := strconv.Atoi(raw)

--- a/internal/server/usage_status_handler_test.go
+++ b/internal/server/usage_status_handler_test.go
@@ -322,6 +322,33 @@ func TestUsageStatusMasterKeyUsesHeaderPath(t *testing.T) {
 	}
 }
 
+func TestUsageStatusCacheMode(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{name: "absent leaves the reader default", target: "/v1/usage", want: ""},
+		{name: "cached", target: "/v1/usage?cache_mode=cached", want: "cached"},
+		{name: "all", target: "/v1/usage?cache_mode=all", want: "all"},
+		{name: "surrounding whitespace is trimmed", target: "/v1/usage?cache_mode=%20all%20", want: "all"},
+		{name: "unknown value reaches the reader, which defaults it", target: "/v1/usage?cache_mode=bogus", want: "bogus"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summarizer := &fakeUsageSummarizer{summary: &usage.UsageSummary{}}
+			rec, _ := getUsageStatus(t, &Config{UsageSummarizer: summarizer}, tc.target, nil)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+			}
+			if summarizer.gotParams.CacheMode != tc.want {
+				t.Fatalf("cache_mode = %q, want %q", summarizer.gotParams.CacheMode, tc.want)
+			}
+		})
+	}
+}
+
 func TestUsageStatusWithoutDependenciesReturnsEmptyStatus(t *testing.T) {
 	rec, body := getUsageStatus(t, &Config{}, "/v1/usage", nil)
 	if rec.Code != http.StatusOK {


### PR DESCRIPTION
Two documentation gaps around the response cache, plus one small API change.

**Cache hits in usage data.** `docs/features/cache.mdx` claimed cache hits are "visible in the regular usage log and summary endpoints", but every usage query excludes them by default — `/admin/usage/summary?user_path=/team/gamma` reported 4 requests where 9 had been served (5 of them from cache), and the `cache_mode` switch that reveals them was documented only in `docs/openapi.json`.

The default is kept: usage totals and cost describe provider spend, which is what budgets enforce and what operators reconcile against invoices; folding free local hits into the same numbers would make requests and cost disagree. What was wrong is that the switch was undiscoverable, so `cache_mode` (`uncached` / `cached` / `all`) is now documented on the admin endpoints and the usage API, and the cache.mdx sentence is corrected.

`/v1/usage` previously ignored `cache_mode` entirely, so a tenant could not see its own cache hits at all. It now accepts the parameter like the admin endpoints do (same default, unknown values fall back to `uncached`). Budgets and rate limits are unaffected — a hit spends nothing and consumes no quota.

**Failover responses are not cached.** Deliberate — the exact-cache key is hashed from the pre-failover resolution, so storing the backup's answer would replay it under the primary's key — but undocumented, and the consequence is sharp: a virtual model whose first target is chronically down gets zero cache benefit while it stays down. Documented in cache.mdx with a cross-reference from failover.mdx.

**Tested.** Live gateway with the exact cache on Redis, sqlite usage store, and a mock upstream: 9 requests under `/team/gamma` (5 cache hits) reproduced summary 4 vs 9 vs 5 for default/`all`/`cached`; `/v1/usage` now moves 12 → 17 → 5 the same way. A `vm-failover` virtual model (always-500 primary, healthy fallback) missed the cache on all 8 requests. New table-driven test in `internal/server/usage_status_handler_test.go`; `go build ./...`, `go test -race ./...`, `make lint` clean (`TZ=UTC`: two version-handler tests are local-timezone flakes unrelated to this change).
