### PR TITLE
fix(responses): complete background responses and drop the model check on lifecycle routes

### DIFF
--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -69,6 +69,20 @@ reaches the provider. When guardrails run and a failover target is
 chat-translated, a native primary receives the replayed history instead of
 the id as well.
 
+## Background responses
+
+`background: true` returns immediately with a `queued` snapshot. Because that
+snapshot is not final, `GET /v1/responses/{id}` re-reads it from the provider
+that created it on every poll and stores the result once the response reaches
+a terminal status (`completed`, `incomplete`, `failed`, or `cancelled`), so the
+usual SDK loop — poll until the status is terminal, then read `output` — works
+through the gateway. Terminal snapshots are served from the store without an
+upstream call. If the refresh fails, the stored snapshot is returned unchanged.
+
+Background creates are never served from the [response
+cache](/features/cache): a `queued` body carries an id that belongs to
+one caller's response.
+
 ## Native provider lookup
 
 When a response was not created through the current GoModel process or response

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -82,7 +82,10 @@ the final request sent upstream. Use `Cache-Control: no-cache` or
 [plugin](/advanced/plugins#decisions) can also keep one response out of both
 layers with `NoStore` on its decision, which a guardrail that restores
 request-specific data into the reply uses so the restored text is never
-replayed to another caller.
+replayed to another caller. A `background: true` request on
+[`/v1/responses`](/advanced/responses-api#background-responses) bypasses both
+layers as well: its `queued` body carries an id that belongs to one caller's
+response.
 
 For the full semantic-cache design and storage options, see
 [ADR-0006](/adr/0006-semantic-response-cache).

--- a/internal/responsecache/exact_cache_test.go
+++ b/internal/responsecache/exact_cache_test.go
@@ -764,3 +764,32 @@ func TestLimitsConcurrentCacheWrites(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 }
+
+func TestHandleRequest_BackgroundResponsesAreNotCached(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	workflow := resolvedWorkflow("openai", "gpt-4")
+	body := []byte(`{"model":"gpt-4","input":"hi","background":true}`)
+	callCount := 0
+	next := func(c *echo.Context) error {
+		callCount++
+		return c.JSON(http.StatusOK, map[string]string{"id": "resp_1", "status": "queued"})
+	}
+
+	if rec := driveHandleRequest(t, mw, workflow, body, nil, next); rec.Code != http.StatusOK {
+		t.Fatalf("first request: got status %d", rec.Code)
+	}
+	mw.simple.wg.Wait()
+
+	rec2 := driveHandleRequest(t, mw, workflow, body, nil, next)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second request: got status %d", rec2.Code)
+	}
+	if got := rec2.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("background create should never be cached, X-Cache=%s", got)
+	}
+	if callCount != 2 {
+		t.Fatalf("callCount = %d, want 2 (no cache replay)", callCount)
+	}
+}

--- a/internal/responsecache/exact_cache_test.go
+++ b/internal/responsecache/exact_cache_test.go
@@ -765,31 +765,69 @@ func TestLimitsConcurrentCacheWrites(t *testing.T) {
 	}
 }
 
-func TestHandleRequest_BackgroundResponsesAreNotCached(t *testing.T) {
-	store := cache.NewMapStore()
-	defer store.Close()
-	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
-	workflow := resolvedWorkflow("openai", "gpt-4")
-	body := []byte(`{"model":"gpt-4","input":"hi","background":true}`)
-	callCount := 0
-	next := func(c *echo.Context) error {
-		callCount++
-		return c.JSON(http.StatusOK, map[string]string{"id": "resp_1", "status": "queued"})
+func TestHandleRequest_BackgroundOnlyBypassesResponsesCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		body      string
+		wantCache string
+		wantCalls int
+	}{
+		{
+			name:      "responses create bypasses the cache",
+			path:      "/v1/responses",
+			body:      `{"model":"gpt-4","input":"hi","background":true}`,
+			wantCache: "",
+			wantCalls: 2,
+		},
+		{
+			name:      "chat completions still caches",
+			path:      "/v1/chat/completions",
+			body:      `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"background":true}`,
+			wantCache: "HIT (exact)",
+			wantCalls: 1,
+		},
 	}
 
-	if rec := driveHandleRequest(t, mw, workflow, body, nil, next); rec.Code != http.StatusOK {
-		t.Fatalf("first request: got status %d", rec.Code)
-	}
-	mw.simple.wg.Wait()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := cache.NewMapStore()
+			defer store.Close()
+			mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+			workflow := resolvedWorkflow("openai", "gpt-4")
+			body := []byte(tt.body)
+			callCount := 0
+			drive := func() *httptest.ResponseRecorder {
+				e := echo.New()
+				req := httptest.NewRequest(http.MethodPost, tt.path, bytes.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req = req.WithContext(core.WithWorkflow(req.Context(), workflow))
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				if err := mw.HandleRequest(c, body, func() error {
+					callCount++
+					return c.JSON(http.StatusOK, map[string]string{"id": "resp_1"})
+				}); err != nil {
+					t.Fatalf("HandleRequest: %v", err)
+				}
+				return rec
+			}
 
-	rec2 := driveHandleRequest(t, mw, workflow, body, nil, next)
-	if rec2.Code != http.StatusOK {
-		t.Fatalf("second request: got status %d", rec2.Code)
-	}
-	if got := rec2.Header().Get("X-Cache"); got != "" {
-		t.Fatalf("background create should never be cached, X-Cache=%s", got)
-	}
-	if callCount != 2 {
-		t.Fatalf("callCount = %d, want 2 (no cache replay)", callCount)
+			if rec := drive(); rec.Code != http.StatusOK {
+				t.Fatalf("first request: got status %d", rec.Code)
+			}
+			mw.simple.wg.Wait()
+
+			rec2 := drive()
+			if rec2.Code != http.StatusOK {
+				t.Fatalf("second request: got status %d", rec2.Code)
+			}
+			if got := rec2.Header().Get("X-Cache"); got != tt.wantCache {
+				t.Fatalf("X-Cache = %q, want %q", got, tt.wantCache)
+			}
+			if callCount != tt.wantCalls {
+				t.Fatalf("callCount = %d, want %d", callCount, tt.wantCalls)
+			}
+		})
 	}
 }

--- a/internal/responsecache/responsecache.go
+++ b/internal/responsecache/responsecache.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v5"
+	"github.com/tidwall/gjson"
 
 	"github.com/enterpilot/gomodel/config"
 	"github.com/enterpilot/gomodel/internal/cache"
@@ -142,6 +143,12 @@ func (m *ResponseCacheMiddleware) handle(ex exchange, body []byte, next func() e
 	if shouldSkipAllCacheHeaders(ex.RequestHeader) {
 		return next()
 	}
+	if requestIsBackground(body) {
+		// A background create only returns a "queued" snapshot whose id is
+		// unique to that request. Replaying it would hand a later caller an
+		// id that belongs to someone else's response.
+		return next()
+	}
 
 	skipExact := strings.EqualFold(ex.RequestHeader("X-Cache-Type"), CacheTypeSemantic)
 	skipSemantic := m.semantic == nil || strings.EqualFold(ex.RequestHeader("X-Cache-Type"), CacheTypeExact)
@@ -165,6 +172,15 @@ func (m *ResponseCacheMiddleware) handle(ex exchange, body []byte, next func() e
 	}
 
 	return innerNext()
+}
+
+// requestIsBackground reports whether a request body asks for background
+// execution (`"background": true` on /v1/responses).
+func requestIsBackground(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	return gjson.GetBytes(body, "background").Bool()
 }
 
 // HandleInternalRequest runs the cache for a transport-free internal JSON

--- a/internal/responsecache/responsecache.go
+++ b/internal/responsecache/responsecache.go
@@ -143,7 +143,7 @@ func (m *ResponseCacheMiddleware) handle(ex exchange, body []byte, next func() e
 	if shouldSkipAllCacheHeaders(ex.RequestHeader) {
 		return next()
 	}
-	if requestIsBackground(body) {
+	if requestIsBackgroundResponsesCreate(ex, body) {
 		// A background create only returns a "queued" snapshot whose id is
 		// unique to that request. Replaying it would hand a later caller an
 		// id that belongs to someone else's response.
@@ -174,10 +174,15 @@ func (m *ResponseCacheMiddleware) handle(ex exchange, body []byte, next func() e
 	return innerNext()
 }
 
-// requestIsBackground reports whether a request body asks for background
-// execution (`"background": true` on /v1/responses).
-func requestIsBackground(body []byte) bool {
+// requestIsBackgroundResponsesCreate reports whether a request creates a
+// background response (`"background": true` on a /v1/responses create). Other
+// endpoints tolerate the field without acting on it, so they keep caching.
+func requestIsBackgroundResponsesCreate(ex exchange, body []byte) bool {
 	if len(body) == 0 {
+		return false
+	}
+	desc := core.DescribeEndpoint(ex.Method(), ex.Path())
+	if desc.Operation != core.OperationResponses || desc.BodyMode != core.BodyModeJSON {
 		return false
 	}
 	return gjson.GetBytes(body, "background").Bool()

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -479,6 +479,7 @@ type mockProvider struct {
 	lastPassthroughReq      *core.PassthroughRequest
 
 	responseGetResponse         *core.ResponsesResponse
+	responseGetHook             func()
 	responseInputItemsResponse  *core.ResponseInputItemListResponse
 	responseCancelResponse      *core.ResponsesResponse
 	responseDeleteResponse      *core.ResponseDeleteResponse
@@ -843,6 +844,9 @@ func (m *mockProvider) Passthrough(_ context.Context, providerType string, req *
 
 func (m *mockProvider) GetResponse(_ context.Context, providerType, id string, _ core.ResponseRetrieveParams) (*core.ResponsesResponse, error) {
 	m.responseGetCalls = append(m.responseGetCalls, responseCall{provider: providerType, id: id})
+	if m.responseGetHook != nil {
+		m.responseGetHook()
+	}
 	if m.responseLifecycleErr != nil {
 		return nil, m.responseLifecycleErr
 	}

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -105,6 +105,17 @@ func deriveWorkflowWithPolicy(
 
 	case core.OperationChatCompletions, core.OperationResponses, core.OperationEmbeddings:
 		workflow.Mode = core.ExecutionModeTranslated
+		if desc.BodyMode != core.BodyModeJSON {
+			// Responses lifecycle routes (GET/DELETE /v1/responses/{id},
+			// /cancel, /input_items) address a stored response by id and carry
+			// no model. Running the create-path model resolution on them turns
+			// any JSON body a client happens to send — `{}` included — into a
+			// misleading "model is required" 400.
+			if err := applyWorkflowPolicy(c.Request().Context(), workflow, policyResolver, core.WorkflowSelector{}); err != nil {
+				return nil, err
+			}
+			return workflow, nil
+		}
 		resolution, parsed, err := ensureRequestModelResolution(c, provider, resolver)
 		if err != nil {
 			return nil, err

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -413,6 +413,13 @@ func (s *nativeResponseService) refreshStoredResponse(
 	if responseStatusPending(resp.Status) {
 		return resp
 	}
+	// A concurrent cancel may have persisted a terminal snapshot while the
+	// provider lookup was in flight. Its outcome wins: the provider's later
+	// body must not turn a cancelled response back into a completed one.
+	if current, currentErr := s.responseStore.Get(ctx, id); currentErr == nil &&
+		current != nil && current.Response != nil && !responseStatusPending(current.Response.Status) {
+		return current.Response
+	}
 	stored.Response = resp
 	stored.Provider = providerType
 	if updateErr := s.responseStore.Update(ctx, stored); updateErr != nil && !errors.Is(updateErr, responsestore.ErrNotFound) {

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -396,13 +396,20 @@ func (s *nativeResponseService) refreshStoredResponse(
 	resp, err := router.GetResponse(ctx, providerRoute, gateway.FirstNonEmpty(stored.ProviderResponseID, id), params)
 	if err != nil || resp == nil {
 		if err != nil && !isUnsupportedNativeResponseError(err) && !isNotFoundGatewayError(err) {
-			slog.Warn("response refresh failed, serving stored snapshot", "response_id", id, "error", err)
+			// The response id comes straight from the request path, so it is
+			// left out of the log line; the audit entry already carries it.
+			slog.Warn("response refresh failed, serving stored snapshot", "provider", providerRoute, "error", err)
 		}
 		return nil
 	}
 
 	providerType := storedProvider(stored)
 	normalizeLifecycleResponse(resp, id, providerType)
+	if resp.PreviousResponseID == "" {
+		// The create path names the predecessor the client asked for; keep it
+		// when the provider does not echo one back.
+		resp.PreviousResponseID = stored.Response.PreviousResponseID
+	}
 	if responseStatusPending(resp.Status) {
 		return resp
 	}
@@ -411,7 +418,7 @@ func (s *nativeResponseService) refreshStoredResponse(
 	if updateErr := s.responseStore.Update(ctx, stored); updateErr != nil && !errors.Is(updateErr, responsestore.ErrNotFound) {
 		// The refreshed response is already correct; a failed write only means
 		// the next poll refreshes again.
-		slog.Warn("failed to persist refreshed response snapshot", "response_id", id, "error", updateErr)
+		slog.Warn("failed to persist refreshed response snapshot", "provider", providerRoute, "error", updateErr)
 	}
 	return resp
 }

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -47,6 +48,9 @@ func (s *nativeResponseService) GetResponse(c *echo.Context) error {
 	stored, err := s.loadStoredResponse(ctx, id)
 	if err == nil {
 		auditResponseEntry(c, storedProvider(stored))
+		if refreshed := s.refreshStoredResponse(ctx, stored, id, params); refreshed != nil {
+			return c.JSON(http.StatusOK, refreshed)
+		}
 		return c.JSON(http.StatusOK, stored.Response)
 	}
 	if err != nil && !errors.Is(err, responsestore.ErrNotFound) {
@@ -122,7 +126,7 @@ func (s *nativeResponseService) CancelResponse(c *echo.Context) error {
 		if resp == nil {
 			return handleError(c, core.NewEmptyProviderResponseError(providerType))
 		}
-		normalizeCanceledResponse(resp, id, providerType)
+		normalizeLifecycleResponse(resp, id, providerType)
 		stored.Response = resp
 		stored.Provider = providerType
 		if updateErr := s.responseStore.Update(ctx, stored); updateErr != nil && !errors.Is(updateErr, responsestore.ErrNotFound) {
@@ -141,7 +145,7 @@ func (s *nativeResponseService) CancelResponse(c *echo.Context) error {
 	if resp == nil {
 		return handleError(c, core.NewEmptyProviderResponseError(providerType))
 	}
-	normalizeCanceledResponse(resp, id, providerType)
+	normalizeLifecycleResponse(resp, id, providerType)
 	auditResponseEntry(c, providerType)
 	return c.JSON(http.StatusOK, resp)
 }
@@ -352,7 +356,67 @@ func (s *nativeResponseService) cancelNativeResponseByRequest(ctx context.Contex
 	})
 }
 
-func normalizeCanceledResponse(resp *core.ResponsesResponse, id, providerType string) {
+// pendingResponseStatuses are the non-final Responses states. A background
+// create is stored as "queued" and only reaches its terminal state upstream,
+// so a snapshot in one of these states must be refreshed before it is served.
+// Every other status — including an empty one from a chat-translated provider
+// that has no native lifecycle to poll — is treated as final.
+var pendingResponseStatuses = map[string]struct{}{
+	"queued":      {},
+	"in_progress": {},
+}
+
+func responseStatusPending(status string) bool {
+	_, pending := pendingResponseStatuses[strings.ToLower(strings.TrimSpace(status))]
+	return pending
+}
+
+// refreshStoredResponse re-reads a pending snapshot from the provider that
+// produced it and persists the result once it is final. It returns nil when
+// the snapshot is already final or the provider cannot serve the lookup, in
+// which case the caller keeps serving the stored snapshot.
+func (s *nativeResponseService) refreshStoredResponse(
+	ctx context.Context,
+	stored *responsestore.StoredResponse,
+	id string,
+	params core.ResponseRetrieveParams,
+) *core.ResponsesResponse {
+	if stored == nil || stored.Response == nil || !responseStatusPending(stored.Response.Status) {
+		return nil
+	}
+	providerRoute := strings.TrimSpace(storedProviderRoute(stored))
+	if providerRoute == "" {
+		return nil
+	}
+	router, ok := s.provider.(core.NativeResponseLifecycleRoutableProvider)
+	if !ok {
+		return nil
+	}
+
+	resp, err := router.GetResponse(ctx, providerRoute, gateway.FirstNonEmpty(stored.ProviderResponseID, id), params)
+	if err != nil || resp == nil {
+		if err != nil && !isUnsupportedNativeResponseError(err) && !isNotFoundGatewayError(err) {
+			slog.Warn("response refresh failed, serving stored snapshot", "response_id", id, "error", err)
+		}
+		return nil
+	}
+
+	providerType := storedProvider(stored)
+	normalizeLifecycleResponse(resp, id, providerType)
+	if responseStatusPending(resp.Status) {
+		return resp
+	}
+	stored.Response = resp
+	stored.Provider = providerType
+	if updateErr := s.responseStore.Update(ctx, stored); updateErr != nil && !errors.Is(updateErr, responsestore.ErrNotFound) {
+		// The refreshed response is already correct; a failed write only means
+		// the next poll refreshes again.
+		slog.Warn("failed to persist refreshed response snapshot", "response_id", id, "error", updateErr)
+	}
+	return resp
+}
+
+func normalizeLifecycleResponse(resp *core.ResponsesResponse, id, providerType string) {
 	if resp == nil {
 		return
 	}

--- a/internal/server/native_response_service_test.go
+++ b/internal/server/native_response_service_test.go
@@ -236,33 +236,51 @@ func TestGetStoredResponseKeepsConcurrentCancellation(t *testing.T) {
 }
 
 func TestGetStoredResponseServesSnapshotWhenRefreshFails(t *testing.T) {
-	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
-	err := store.Create(context.Background(), &responsestore.StoredResponse{
-		Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "in_progress"},
-		Provider:           "mock",
-		ProviderResponseID: "provider_resp",
-	})
-	if err != nil {
-		t.Fatalf("store.Create() error = %v", err)
+	tests := []struct {
+		name         string
+		lifecycleErr error
+	}{
+		{name: "unsupported operation", lifecycleErr: unsupportedResponseOperation("native response retrieval is not available for this provider")},
+		{name: "not found upstream", lifecycleErr: core.NewNotFoundError("response not found")},
+		{name: "unexpected provider error", lifecycleErr: errors.New("refresh failed")},
 	}
-	provider := &mockProvider{
-		responseLifecycleErr: unsupportedResponseOperation("native response retrieval is not available for this provider"),
-	}
-	srv := New(provider, &Config{ResponseStore: store})
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_gateway", nil)
-	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+			err := store.Create(context.Background(), &responsestore.StoredResponse{
+				Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "in_progress"},
+				Provider:           "mock",
+				ProviderResponseID: "provider_resp",
+			})
+			if err != nil {
+				t.Fatalf("store.Create() error = %v", err)
+			}
+			provider := &mockProvider{responseLifecycleErr: tt.lifecycleErr}
+			srv := New(provider, &Config{ResponseStore: store})
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
-	}
-	var resp core.ResponsesResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if resp.Status != "in_progress" || resp.ID != "resp_gateway" {
-		t.Fatalf("response = %+v, want the stored snapshot", resp)
+			req := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_gateway", nil)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+			}
+			var resp core.ResponsesResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.Status != "in_progress" || resp.ID != "resp_gateway" {
+				t.Fatalf("response = %+v, want the stored snapshot", resp)
+			}
+			stored, err := store.Get(context.Background(), "resp_gateway")
+			if err != nil {
+				t.Fatalf("store.Get() error = %v", err)
+			}
+			if stored.Response.Status != "in_progress" {
+				t.Fatalf("stored status = %q, want the snapshot left unchanged", stored.Response.Status)
+			}
+		})
 	}
 }
 

--- a/internal/server/native_response_service_test.go
+++ b/internal/server/native_response_service_test.go
@@ -185,6 +185,56 @@ func TestGetStoredResponseKeepsTerminalSnapshot(t *testing.T) {
 	}
 }
 
+func TestGetStoredResponseKeepsConcurrentCancellation(t *testing.T) {
+	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+	err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "queued"},
+		Provider:           "mock",
+		ProviderResponseID: "provider_resp",
+	})
+	if err != nil {
+		t.Fatalf("store.Create() error = %v", err)
+	}
+	provider := &mockProvider{
+		responseGetResponse: &core.ResponsesResponse{ID: "provider_resp", Object: "response", Status: "completed"},
+	}
+	// A cancel lands while the provider lookup is in flight.
+	provider.responseGetHook = func() {
+		updateErr := store.Update(context.Background(), &responsestore.StoredResponse{
+			Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "cancelled"},
+			Provider:           "mock",
+			ProviderResponseID: "provider_resp",
+		})
+		if updateErr != nil {
+			t.Errorf("store.Update() error = %v", updateErr)
+		}
+	}
+	srv := New(provider, &Config{ResponseStore: store})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_gateway", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var resp core.ResponsesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "cancelled" {
+		t.Fatalf("status = %q, want the cancellation to win", resp.Status)
+	}
+
+	stored, err := store.Get(context.Background(), "resp_gateway")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if stored.Response.Status != "cancelled" {
+		t.Fatalf("stored status = %q, want cancelled", stored.Response.Status)
+	}
+}
+
 func TestGetStoredResponseServesSnapshotWhenRefreshFails(t *testing.T) {
 	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
 	err := store.Create(context.Background(), &responsestore.StoredResponse{

--- a/internal/server/native_response_service_test.go
+++ b/internal/server/native_response_service_test.go
@@ -107,6 +107,147 @@ func TestCancelStoredResponseNormalizesPersistedResponse(t *testing.T) {
 	}
 }
 
+func TestGetStoredResponseRefreshesNonTerminalSnapshot(t *testing.T) {
+	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+	err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "queued"},
+		Provider:           "mock",
+		ProviderResponseID: "provider_resp",
+	})
+	if err != nil {
+		t.Fatalf("store.Create() error = %v", err)
+	}
+	provider := &mockProvider{
+		responseGetResponse: &core.ResponsesResponse{
+			ID:       "provider_resp",
+			Object:   "response",
+			Provider: "upstream",
+			Status:   "completed",
+			Output: []core.ResponsesOutputItem{
+				{ID: "msg_1", Type: "message", Role: "assistant"},
+			},
+		},
+	}
+	srv := New(provider, &Config{ResponseStore: store})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_gateway", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var resp core.ResponsesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "completed" {
+		t.Fatalf("status = %q, want completed", resp.Status)
+	}
+	if resp.ID != "resp_gateway" || resp.Object != "response" || resp.Provider != "mock" {
+		t.Fatalf("response = %+v, want gateway id/object/provider", resp)
+	}
+	if len(provider.responseGetCalls) != 1 || provider.responseGetCalls[0].id != "provider_resp" {
+		t.Fatalf("provider get calls = %+v, want one lookup of provider_resp", provider.responseGetCalls)
+	}
+
+	stored, err := store.Get(context.Background(), "resp_gateway")
+	if err != nil {
+		t.Fatalf("store.Get() error = %v", err)
+	}
+	if stored.Response.Status != "completed" || stored.Response.ID != "resp_gateway" {
+		t.Fatalf("stored response = %+v, want persisted terminal snapshot", stored.Response)
+	}
+}
+
+func TestGetStoredResponseKeepsTerminalSnapshot(t *testing.T) {
+	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+	err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "completed"},
+		Provider:           "mock",
+		ProviderResponseID: "provider_resp",
+	})
+	if err != nil {
+		t.Fatalf("store.Create() error = %v", err)
+	}
+	provider := &mockProvider{}
+	srv := New(provider, &Config{ResponseStore: store})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_gateway", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if len(provider.responseGetCalls) != 0 {
+		t.Fatalf("provider get calls = %+v, want none for a terminal snapshot", provider.responseGetCalls)
+	}
+}
+
+func TestGetStoredResponseServesSnapshotWhenRefreshFails(t *testing.T) {
+	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+	err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response:           &core.ResponsesResponse{ID: "resp_gateway", Object: "response", Provider: "mock", Status: "in_progress"},
+		Provider:           "mock",
+		ProviderResponseID: "provider_resp",
+	})
+	if err != nil {
+		t.Fatalf("store.Create() error = %v", err)
+	}
+	provider := &mockProvider{
+		responseLifecycleErr: unsupportedResponseOperation("native response retrieval is not available for this provider"),
+	}
+	srv := New(provider, &Config{ResponseStore: store})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_gateway", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	var resp core.ResponsesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "in_progress" || resp.ID != "resp_gateway" {
+		t.Fatalf("response = %+v, want the stored snapshot", resp)
+	}
+}
+
+func TestResponseLifecycleRoutesIgnoreJSONBody(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{name: "cancel empty object", method: http.MethodPost, path: "/v1/responses/resp_gateway/cancel?provider=mock", body: `{}`, want: http.StatusOK},
+		{name: "cancel unrelated field", method: http.MethodPost, path: "/v1/responses/resp_gateway/cancel?provider=mock", body: `{"foo":1}`, want: http.StatusOK},
+		{name: "retrieve with body", method: http.MethodGet, path: "/v1/responses/resp_gateway?provider=mock", body: `{}`, want: http.StatusOK},
+		{name: "input items with body", method: http.MethodGet, path: "/v1/responses/resp_gateway/input_items?provider=mock", body: `{}`, want: http.StatusOK},
+		{name: "delete with body", method: http.MethodDelete, path: "/v1/responses/resp_gateway?provider=mock", body: `{}`, want: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &mockProvider{}
+			srv := New(provider, nil)
+
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d (%s)", rec.Code, tt.want, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestNativeResponseByProviderWrapsContextCancellation(t *testing.T) {
 	provider := &mockProvider{
 		providerTypes: map[string]string{


### PR DESCRIPTION
Two fixes on the Responses lifecycle routes.

**`background: true` responses never completed.** `POST /v1/responses` with `background: true` stored the `queued` snapshot, and `GET /v1/responses/{id}` short-circuited on any stored snapshot, so the poll returned `queued` with an empty `output` forever even though the upstream response had completed. A snapshot in a non-final state (`queued`, `in_progress`) is now refreshed from the provider that created it and persisted once it reaches a terminal status, so the usual SDK loop (poll until terminal, then read `output`) works. Terminal snapshots are still served from the store with no upstream call, so chat-translated providers are unaffected; if the refresh fails, the stored snapshot is returned unchanged. A `background: true` create also no longer goes through the response cache — replaying a cached `queued` body handed a later caller an id belonging to someone else's response.

**`POST /v1/responses/{id}/cancel` returned `400 model is required` for any JSON body**, `{}` included (an empty body worked); the same applied to `GET`/`DELETE /v1/responses/{id}` and `/input_items`. Every `/v1/responses*` sub-path is classified as the Responses operation, so the create-path model resolution ran on the lifecycle routes, where no `model` exists. Model resolution is now limited to the endpoints that actually take a JSON body (`POST /v1/responses`, `/input_tokens`, `/compact`); lifecycle routes take the same path they already took for an empty body, so auth, scoping and rate limiting are unchanged.

Tested: handler tests for both (refresh, terminal snapshot untouched, refresh failure falls back, lifecycle routes with a JSON body) plus a cache-bypass test; `go test -race ./...` and `make lint`. Live against OpenAI on `gpt-4.1-mini`: a background create now reaches `completed` with output on poll; a background response cancels with a `{}` body; `anthropic/claude-haiku-4-5` still serves its stored snapshot and returns the documented `501` on cancel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for background Responses API requests that return immediately with a queued status.
  * Polling refreshes queued or in-progress responses until they reach a terminal status.
  * Terminal responses are served from stored results without additional provider requests.

* **Bug Fixes**
  * Background responses now bypass response caching to prevent replaying caller-specific results.
  * Failed refreshes preserve and return the last stored response.
  * Response lifecycle endpoints now handle requests without requiring JSON bodies.

* **Documentation**
  * Documented background response behavior and cache handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->