### PR TITLE
fix(cache): route /v1/embeddings through the response cache

### DIFF
--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -32,6 +32,14 @@ can reuse a stored response:
 X-Cache: HIT (semantic)
 ```
 
+<Note>
+  `/v1/embeddings` participates in the exact cache only. An embedding has to
+  represent the exact text it was requested for, so replaying the vector of a
+  merely similar input would be a wrong answer rather than an equivalent one.
+  Embeddings requests are also never streamed, so only the JSON response is
+  cached.
+</Note>
+
 ## Enable the exact cache
 
 Point response caching at Redis:

--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -520,6 +520,140 @@ func TestHandleRequest_ExactHitWritesSyntheticUsageEntry(t *testing.T) {
 	}
 }
 
+// TestHandleRequest_EmbeddingsExactHitWritesUsageEntry covers /v1/embeddings on
+// the exact layer: the hit replays the stored vector and records the usage row
+// a cached chat hit records, with the embeddings token shape.
+func TestHandleRequest_EmbeddingsExactHitWritesUsageEntry(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+
+	logger := &recordingUsageLogger{}
+	m := &ResponseCacheMiddleware{
+		simple: newSimpleCacheMiddleware(store, time.Hour, newUsageHitRecorder(logger, nil)),
+	}
+
+	body := []byte(`{"model":"text-embedding-3-small","input":"cache-embeddings-hit"}`)
+	e := echo.New()
+
+	providerCalls := 0
+	run := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		plan := &core.Workflow{
+			Mode:         core.ExecutionModeTranslated,
+			ProviderType: "openai",
+			Resolution: &core.RequestModelResolution{
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "text-embedding-3-small"},
+			},
+		}
+		c.SetRequest(req.WithContext(core.WithWorkflow(req.Context(), plan)))
+		if err := m.HandleRequest(c, body, func() error {
+			providerCalls++
+			return c.JSON(http.StatusOK, &core.EmbeddingResponse{
+				Object: "list",
+				Model:  "text-embedding-3-small",
+				Data: []core.EmbeddingData{
+					{Object: "embedding", Embedding: []byte(`[0.5,0.25]`), Index: 0},
+				},
+				Usage: core.EmbeddingUsage{PromptTokens: 7, TotalTokens: 7},
+			})
+		}); err != nil {
+			t.Fatalf("HandleRequest: %v", err)
+		}
+		return rec
+	}
+
+	rec1 := run()
+	if rec1.Header().Get("X-Cache") != "" {
+		t.Fatalf("first request should miss exact cache, got X-Cache=%q", rec1.Header().Get("X-Cache"))
+	}
+
+	m.simple.wg.Wait()
+
+	rec2 := run()
+	if rec2.Header().Get("X-Cache") != "HIT (exact)" {
+		t.Fatalf("second request should be exact hit, got X-Cache=%q", rec2.Header().Get("X-Cache"))
+	}
+	if providerCalls != 1 {
+		t.Fatalf("provider calls = %d, want 1", providerCalls)
+	}
+	if rec2.Body.String() != rec1.Body.String() {
+		t.Fatalf("cached body = %s, want %s", rec2.Body.String(), rec1.Body.String())
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("expected 1 synthetic usage entry, got %d", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.CacheType != usage.CacheTypeExact {
+		t.Fatalf("CacheType = %q, want %q", entry.CacheType, usage.CacheTypeExact)
+	}
+	if entry.Endpoint != "/v1/embeddings" {
+		t.Fatalf("Endpoint = %q, want /v1/embeddings", entry.Endpoint)
+	}
+	if entry.InputTokens != 7 || entry.OutputTokens != 0 || entry.TotalTokens != 7 {
+		t.Fatalf("unexpected tokens: %+v", entry)
+	}
+}
+
+// TestHandleRequest_EmbeddingsSkipSemanticLayer pins that embeddings never take
+// part in semantic caching: a near-match must not answer with another input's
+// vector, and the lookup must not spend an embedder call.
+func TestHandleRequest_EmbeddingsSkipSemanticLayer(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+
+	emb := &mockEmbedder{vector: []float32{1, 0, 0}}
+	vecStore := NewMapVecStore()
+	semCfg := config.SemanticCacheConfig{
+		SimilarityThreshold:     0.50,
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
+	}
+	m := &ResponseCacheMiddleware{
+		simple:   newSimpleCacheMiddleware(store, time.Hour, nil),
+		semantic: newSemanticCacheMiddleware(emb, vecStore, semCfg, nil),
+	}
+
+	e := echo.New()
+	providerCalls := 0
+	run := func(input string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := []byte(`{"model":"text-embedding-3-small","input":"` + input + `"}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		if err := m.HandleRequest(c, body, func() error {
+			providerCalls++
+			return c.JSON(http.StatusOK, map[string]string{"input": input})
+		}); err != nil {
+			t.Fatalf("HandleRequest: %v", err)
+		}
+		return rec
+	}
+
+	run("the cat sat on the mat")
+	m.simple.wg.Wait()
+	m.semantic.wg.Wait()
+
+	rec := run("a cat sat upon the mat")
+	if got := rec.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("similar embeddings input X-Cache = %q, want a miss", got)
+	}
+	if providerCalls != 2 {
+		t.Fatalf("provider calls = %d, want 2", providerCalls)
+	}
+	if emb.calls != 0 {
+		t.Fatalf("embedder calls = %d, want 0 for /v1/embeddings", emb.calls)
+	}
+	if vecStore.Len() != 0 {
+		t.Fatalf("semantic store entries = %d, want 0 for /v1/embeddings", vecStore.Len())
+	}
+}
+
 func TestHandleRequest_AuditMiddlewarePreservesCommittedErrorStatus(t *testing.T) {
 	store := cache.NewMapStore()
 	defer store.Close()

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -113,7 +113,7 @@ func (m *semanticCacheMiddleware) Handle(ex exchange, body []byte, next func() e
 	}
 
 	path := ex.Path()
-	if !cacheablePaths[path] || ex.Method() != http.MethodPost {
+	if !semanticCacheablePath(path) || ex.Method() != http.MethodPost {
 		return next()
 	}
 

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -20,10 +20,20 @@ import (
 	"github.com/enterpilot/gomodel/internal/core"
 )
 
+const embeddingsPath = "/v1/embeddings"
+
 var cacheablePaths = map[string]bool{
 	"/v1/chat/completions": true,
 	"/v1/responses":        true,
-	"/v1/embeddings":       true,
+	embeddingsPath:         true,
+}
+
+// semanticCacheablePath reports whether a path may be served from the semantic
+// layer. Embeddings are excluded on purpose: an embedding must represent the
+// exact text it was requested for, so replaying the vector of a merely similar
+// input would return a wrong answer rather than an equivalent one.
+func semanticCacheablePath(path string) bool {
+	return cacheablePaths[path] && path != embeddingsPath
 }
 
 const (
@@ -246,7 +256,7 @@ func isStreamingRequest(path string, body []byte) bool {
 }
 
 func isStreamingRequestGJSON(path string, body []byte) bool {
-	if path == "/v1/embeddings" {
+	if path == embeddingsPath {
 		return false
 	}
 	// gjson returns the first matching top-level field. That differs from

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -475,6 +475,7 @@ type mockProvider struct {
 	passthroughResponse     *core.PassthroughResponse
 	passthroughErr          error
 	chatCompletionCalls     int
+	embeddingCalls          int
 	lastPassthroughProvider string
 	lastPassthroughReq      *core.PassthroughRequest
 
@@ -820,6 +821,7 @@ func (m *mockProvider) StreamResponses(_ context.Context, _ *core.ResponsesReque
 }
 
 func (m *mockProvider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	m.embeddingCalls++
 	if m.embeddingErr != nil {
 		return nil, m.embeddingErr
 	}
@@ -3256,6 +3258,135 @@ func TestEmbeddings_ProviderReturnsError(t *testing.T) {
 	body := rec.Body.String()
 	if !strings.Contains(body, "embeddings not supported") {
 		t.Errorf("expected error message about embeddings, got: %s", body)
+	}
+}
+
+// TestEmbeddings_ExactCache covers the exact cache on /v1/embeddings: an
+// identical repeat is served from the cache, and anything the provider would
+// answer differently for (input, model, dimensions, encoding_format) or a
+// no-store request still reaches the provider.
+func TestEmbeddings_ExactCache(t *testing.T) {
+	const firstBody = `{"model":"text-embedding-3-small","input":"hello world","dimensions":256,"encoding_format":"float"}`
+
+	tests := []struct {
+		name       string
+		secondBody string
+		header     string
+		wantHit    bool
+	}{
+		{name: "identical request hits", secondBody: firstBody, wantHit: true},
+		{name: "reformatted request hits", secondBody: `{ "input":"hello world", "model":"text-embedding-3-small", "encoding_format":"float", "dimensions":256 }`, wantHit: true},
+		{name: "different input misses", secondBody: `{"model":"text-embedding-3-small","input":"goodbye world","dimensions":256,"encoding_format":"float"}`},
+		{name: "different model misses", secondBody: `{"model":"text-embedding-3-large","input":"hello world","dimensions":256,"encoding_format":"float"}`},
+		{name: "different dimensions misses", secondBody: `{"model":"text-embedding-3-small","input":"hello world","dimensions":512,"encoding_format":"float"}`},
+		{name: "different encoding_format misses", secondBody: `{"model":"text-embedding-3-small","input":"hello world","dimensions":256,"encoding_format":"base64"}`},
+		{name: "different user misses", secondBody: `{"model":"text-embedding-3-small","input":"hello world","dimensions":256,"encoding_format":"float","user":"tenant-b"}`},
+		{name: "no-store bypasses", secondBody: firstBody, header: "no-store"},
+		{name: "no-cache bypasses", secondBody: firstBody, header: "no-cache"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockProvider{
+				supportedModels: []string{"text-embedding-3-small", "text-embedding-3-large"},
+				embeddingResponse: &core.EmbeddingResponse{
+					Object: "list",
+					Data: []core.EmbeddingData{
+						{Object: "embedding", Embedding: json.RawMessage(`[0.1,0.2,0.3]`), Index: 0},
+					},
+					Model: "text-embedding-3-small",
+					Usage: core.EmbeddingUsage{PromptTokens: 5, TotalTokens: 5},
+				},
+			}
+
+			store := cache.NewMapStore()
+			defer store.Close()
+			mw := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+			defer mw.Close()
+
+			e := echo.New()
+			handler := NewHandler(mock, nil, nil, nil)
+			handler.responseCache = mw
+
+			call := func(body, cacheControl string) *httptest.ResponseRecorder {
+				t.Helper()
+				req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				if cacheControl != "" {
+					req.Header.Set("Cache-Control", cacheControl)
+				}
+				rec := httptest.NewRecorder()
+				if err := handler.Embeddings(e.NewContext(req, rec)); err != nil {
+					t.Fatalf("handler.Embeddings() error = %v", err)
+				}
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+				}
+				return rec
+			}
+
+			first := call(firstBody, "")
+			if got := first.Header().Get("X-Cache"); got != "" {
+				t.Fatalf("first request X-Cache = %q, want empty", got)
+			}
+			// The cache write is asynchronous; drain it before the repeat.
+			if err := mw.Close(); err != nil {
+				t.Fatalf("flush cache writes: %v", err)
+			}
+
+			second := call(tt.secondBody, tt.header)
+			gotHit := second.Header().Get("X-Cache") == "HIT (exact)"
+			if gotHit != tt.wantHit {
+				t.Fatalf("second request X-Cache = %q, want hit = %v", second.Header().Get("X-Cache"), tt.wantHit)
+			}
+			wantCalls := 2
+			if tt.wantHit {
+				wantCalls = 1
+				if second.Body.String() != first.Body.String() {
+					t.Fatalf("cached body = %s, want %s", second.Body.String(), first.Body.String())
+				}
+			}
+			if mock.embeddingCalls != wantCalls {
+				t.Fatalf("provider calls = %d, want %d", mock.embeddingCalls, wantCalls)
+			}
+		})
+	}
+}
+
+// TestEmbeddings_ProviderErrorNotCached ensures a failed embeddings request is
+// not stored, so the retry still reaches the provider.
+func TestEmbeddings_ProviderErrorNotCached(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"text-embedding-3-small"},
+		embeddingErr:    core.NewProviderError("openai", http.StatusInternalServerError, "boom", nil),
+	}
+
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	defer mw.Close()
+
+	e := echo.New()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.responseCache = mw
+
+	const body = `{"model":"text-embedding-3-small","input":"hello world"}`
+	for i := range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		if err := handler.Embeddings(e.NewContext(req, rec)); err != nil {
+			t.Fatalf("handler.Embeddings() error = %v", err)
+		}
+		if rec.Code == http.StatusOK {
+			t.Fatalf("request %d: status = 200, want an error status", i+1)
+		}
+		if got := rec.Header().Get("X-Cache"); got != "" {
+			t.Fatalf("request %d: X-Cache = %q, want empty", i+1, got)
+		}
+	}
+	if mock.embeddingCalls != 2 {
+		t.Fatalf("provider calls = %d, want 2", mock.embeddingCalls)
 	}
 }
 

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -582,20 +582,24 @@ func (s *translatedInferenceService) Embeddings(c *echo.Context) error {
 	}
 	attachPreparedWorkflow(c, prepared.Context, prepared.Workflow)
 
-	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker, rateLimitRouteFromWorkflow(prepared.Workflow))
+	return handleWithCache(s, c, prepared.Request, prepared.Workflow, s.dispatchEmbeddings)
+}
+
+func (s *translatedInferenceService) dispatchEmbeddings(c *echo.Context, req *core.EmbeddingRequest, workflow *core.Workflow) error {
+	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker, rateLimitRouteFromWorkflow(workflow))
 	if err != nil {
 		return handleError(c, err)
 	}
 	defer adm.release()
 
 	requestID := requestIDFromContextOrHeader(c.Request())
-	result, err := s.inference().ExecuteEmbeddings(c.Request().Context(), prepared.Workflow, prepared.Request, requestID, "/v1/embeddings")
+	result, err := s.inference().ExecuteEmbeddings(c.Request().Context(), workflow, req, requestID, "/v1/embeddings")
 	if err != nil {
 		return handleError(c, err)
 	}
 	auditlog.EnrichEntryWithResolvedRoute(
 		c,
-		qualifyExecutedModel(prepared.Workflow, result.Response.Model, result.Meta.ProviderName),
+		qualifyExecutedModel(workflow, result.Response.Model, result.Meta.ProviderName),
 		result.Meta.ProviderType,
 		result.Meta.ProviderName,
 	)


### PR DESCRIPTION
`POST /v1/embeddings` never participated in the response cache: the handler called `PrepareEmbeddingRequest` → `enforceAdmission` → `ExecuteEmbeddings` directly and skipped `handleWithCache`, even though the docs list it as a cached endpoint and `cacheablePaths` already contained it. Every repeat request reached the provider and no response carried `X-Cache`.

User-visible impact:

- Identical embeddings requests are now served from the exact cache with `X-Cache: HIT (exact)` and record the same synthetic usage/cost row a cached chat hit records.
- The key is the normal exact-cache key (path + resolved workflow + resolved guardrail chain + final body), so model, input, `dimensions`, `encoding_format` and any passthrough field such as `user` all change the entry; `Cache-Control: no-cache|no-store` bypasses it; non-200 responses are never stored; embeddings are never streamed.
- `user_path` remains outside the exact-cache key, exactly as on the chat path and as documented under "`user_path` behavior".
- Embeddings are excluded from the semantic layer: an embedding must represent the exact text it was requested for, so a near-match vector would be a wrong answer rather than an equivalent one. Documented in docs/features/cache.mdx.

Tested: new table-driven handler tests (hit / reformatted body / input, model, dimensions, encoding_format, user changes / no-store / no-cache / provider error not cached) and responsecache tests for the cached-hit usage entry and the semantic bypass; `go build ./...`, `go test ./...`, `make lint`. Live against a mock upstream with a request counter (10 requests → 5 upstream calls) and against `openai/text-embedding-3-small` (identical repeat returned the identical 1536-dim vector as a hit; `dimensions` and input changes missed; `no-store` bypassed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added exact-response caching for embedding requests.
  - Repeated, equivalent embedding requests can now be served from cache while preserving usage information.
  - Requests with different inputs or parameters continue to be processed independently.

- **Bug Fixes**
  - Embedding requests are excluded from semantic caching to prevent inaccurate results from similar, but non-identical, inputs.
  - Failed embedding requests are not cached.
  - Cache-control headers such as `no-store` and `no-cache` continue to bypass caching.

- **Documentation**
  - Clarified embedding cache behavior and non-streaming response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->