### PR TITLE
fix(messages): always render a signature on thinking blocks

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -8756,7 +8756,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "signature": {
-                    "description": "Signature authenticates a thinking block. Anthropic requires it back\nverbatim when the conversation continues, so clients must echo it.",
+                    "description": "Signature authenticates a thinking block. Anthropic requires it back\nverbatim when the conversation continues, so clients must echo it. Every\nthinking block carries the member, as the Anthropic schema requires;\nreasoning from a provider that does not sign its output is rendered with\nan empty signature. Hence the pointer: only a thinking block has one.",
                     "type": "string"
                 },
                 "text": {

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -197,6 +197,13 @@ features that have no canonical equivalent are not preserved end to end:
   `signature_delta` when streaming), and an assistant turn echoed back is
   replayed unchanged, so thinking-enabled conversations and tool-use loops
   continue correctly. Other providers never see them.
+- **Reasoning from a provider that does not sign it** (DeepSeek, Fireworks, …)
+  is returned as a `thinking` block with `signature: ""` — the member is
+  required by the Anthropic schema, and the empty value says the reasoning is
+  unsigned. Echo the turn back as-is: the block replays to that provider like
+  any other. Anthropic accepts only signatures it minted itself, so a turn
+  carrying an unsigned block is stripped of it before reaching Claude (the rest
+  of the turn is sent unchanged).
 - **`tool_result.is_error`** is preserved when routed to Anthropic. Other
   providers have no equivalent flag and receive the result content only.
 - **`tool_use.extra_content`** carries another provider's replay state, such as

--- a/docs/advanced/extra-content.mdx
+++ b/docs/advanced/extra-content.mdx
@@ -273,6 +273,21 @@ included, because that is what an Anthropic client echoes back:
 Streaming emits the signature as a `signature_delta` inside the thinking
 block, before it closes, exactly as Anthropic does.
 
+### Reasoning from providers that do not sign it
+
+DeepSeek, Fireworks and other providers return reasoning text with nothing to
+authenticate it. The Anthropic Messages API still renders it as a `thinking`
+block, with `signature: ""` — the schema marks the member required, so a
+strictly typed client would reject a block that omits it, and streaming opens
+the block with an empty signature and sends no `signature_delta`, which is the
+shape Anthropic itself streams before the real signature arrives. Echo the turn
+back unchanged: the block replays to that provider like any other.
+
+Anthropic accepts only signatures it minted (a missing one fails with
+`signature: Field required`, anything else with ``Invalid `signature` in
+`thinking` block``), so when such a history is routed to Anthropic the unsigned
+block is dropped and the rest of the turn is sent as usual.
+
 The other dialects have no thinking block, so they carry the same data under
 `extra_content.anthropic.thinking_blocks` — on the assistant message in Chat
 Completions, on the `reasoning` output item in the Responses API. Streaming
@@ -310,7 +325,7 @@ before dispatch, on every route, in every dialect.
 | --- | --- | --- |
 | `extra_content.google` | `gemini`, `vertex` | the signature, replayed on the matching part |
 | `extra_content.google` | any other provider | nothing; the member is dropped |
-| `extra_content.anthropic` | `anthropic` | thinking blocks and `is_error`, restored in place |
+| `extra_content.anthropic` | `anthropic` | thinking blocks and `is_error`, restored in place; a thinking block Anthropic did not sign is dropped |
 | `extra_content.anthropic` | any other provider | nothing; the member is dropped |
 
 The client's own history is never modified. The filtering happens on the copy

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12491,7 +12491,7 @@
             "type": "string"
           },
           "signature": {
-            "description": "Signature authenticates a thinking block. Anthropic requires it back\nverbatim when the conversation continues, so clients must echo it.",
+            "description": "Signature authenticates a thinking block. Anthropic requires it back\nverbatim when the conversation continues, so clients must echo it. Every\nthinking block carries the member, as the Anthropic schema requires;\nreasoning from a provider that does not sign its output is rendered with\nan empty signature. Hence the pointer: only a thinking block has one.",
             "type": "string"
           },
           "text": {

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -51,6 +51,33 @@ func ToChatRequestLenient(req *MessagesRequest) (*core.ChatRequest, error) {
 	return toChatRequest(req, true)
 }
 
+// HasUnsignedThinking reports whether an assistant turn replays a thinking
+// block with no signature. Such a block is reasoning some other provider
+// produced (the gateway renders it with an empty signature, because the
+// Anthropic schema requires the member); Anthropic refuses any signature it did
+// not mint, so a request carrying one must take the translated pipeline, which
+// drops the block, instead of being forwarded to Claude verbatim.
+func HasUnsignedThinking(req *MessagesRequest) bool {
+	if req == nil {
+		return false
+	}
+	for _, message := range req.Messages {
+		if message.Role != "assistant" {
+			continue
+		}
+		_, blocks, err := parseContent(message.Content)
+		if err != nil {
+			continue
+		}
+		for _, block := range blocks {
+			if block.Type == "thinking" && strings.TrimSpace(block.Signature) == "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func toChatRequest(req *MessagesRequest, lenient bool) (*core.ChatRequest, error) {
 	if req == nil {
 		return nil, core.NewInvalidRequestError("messages request is required", nil)

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -832,6 +832,87 @@ func TestToChatRequestPreservesAssistantThinkingBlocks(t *testing.T) {
 	}
 }
 
+// The documented agent loop echoes the assistant turn back verbatim. A turn
+// from a provider that does not sign its reasoning carries an empty signature,
+// which must survive the round trip as replay state rather than failing the
+// request: the block reaches the same provider again, and the Anthropic egress
+// drops it before it can reach Claude.
+func TestMessagesRoundTripUnsignedThinking(t *testing.T) {
+	resp := &core.ChatResponse{Choices: []core.Choice{{
+		Message: core.ResponseMessage{
+			Role:        "assistant",
+			Content:     "391",
+			ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{"reasoning_content": json.RawMessage(`"17*23"`)}),
+		},
+		FinishReason: "stop",
+	}}}
+	content, err := json.Marshal(FromChatResponse(resp).Content)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(content), `"signature":""`) {
+		t.Fatalf("content = %s, want an empty signature on the thinking block", content)
+	}
+
+	body := `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":` +
+		string(content) + `},{"role":"user","content":"and now?"}]}`
+	decoded := mustDecode(t, body)
+	if !HasUnsignedThinking(decoded) {
+		t.Error("HasUnsignedThinking = false, want the replayed unsigned block detected")
+	}
+	chat, err := ToChatRequest(decoded)
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	want := `{"thinking_blocks":[{"type":"thinking","thinking":"17*23"}]}`
+	if got := string(chat.Messages[1].ExtraFields.ExtraContent(core.ExtraContentVendorAnthropic)); got != want {
+		t.Errorf("extra_content.anthropic = %s, want %s", got, want)
+	}
+}
+
+func TestHasUnsignedThinking(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "signed assistant thinking",
+			body: `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"t","signature":"sig"}]}]}`,
+		},
+		{
+			name: "redacted thinking carries data instead of a signature",
+			body: `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":[{"type":"redacted_thinking","data":"opaque"}]}]}`,
+		},
+		{
+			name: "string content",
+			body: `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":"hi"}]}`,
+		},
+		{
+			name: "a stray user thinking block is not replay state",
+			body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"thinking","thinking":"t"}]}]}`,
+		},
+		{
+			name: "missing signature",
+			body: `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"t"}]}]}`,
+			want: true,
+		},
+		{
+			name: "empty signature",
+			body: `{"model":"m","max_tokens":10,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"t","signature":"  "}]}]}`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasUnsignedThinking(mustDecode(t, tt.body)); got != tt.want {
+				t.Errorf("HasUnsignedThinking = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestToChatRequestLenientDropsUnsupportedContent(t *testing.T) {
 	body := `{
 		"model":"m","max_tokens":10,

--- a/internal/anthropicapi/response.go
+++ b/internal/anthropicapi/response.go
@@ -31,7 +31,7 @@ func FromChatResponse(resp *core.ChatResponse) *MessagesResponse {
 		if blocks, ok := thinkingBlocks(choice.Message.ExtraFields); ok {
 			out.Content = append(out.Content, blocks...)
 		} else if thinking := reasoningContent(choice.Message.ExtraFields); thinking != "" {
-			out.Content = append(out.Content, ResponseContentBlock{Type: "thinking", Thinking: thinking})
+			out.Content = append(out.Content, unsignedThinkingBlock(thinking))
 		}
 		if text := core.ExtractTextContent(choice.Message.Content); text != "" {
 			out.Content = append(out.Content, ResponseContentBlock{Type: "text", Text: text})
@@ -101,7 +101,27 @@ func thinkingBlocks(fields core.UnknownJSONFields) ([]ResponseContentBlock, bool
 	if err := json.Unmarshal(raw, &extra); err != nil || len(extra.ThinkingBlocks) == 0 {
 		return nil, false
 	}
+	for i, block := range extra.ThinkingBlocks {
+		if block.Type == "thinking" && block.Signature == nil {
+			extra.ThinkingBlocks[i].Signature = emptySignature()
+		}
+	}
 	return extra.ThinkingBlocks, true
+}
+
+// unsignedThinkingBlock renders reasoning text a provider produced without a
+// signature. The Anthropic schema marks signature required on a thinking
+// block, so a strictly typed client rejects a block that omits it; the empty
+// string says "this reasoning is not signed" without pretending otherwise.
+// Anthropic refuses any signature it did not mint, so the gateway drops such a
+// block again on its way back in rather than forwarding it to Claude.
+func unsignedThinkingBlock(thinking string) ResponseContentBlock {
+	return ResponseContentBlock{Type: "thinking", Thinking: thinking, Signature: emptySignature()}
+}
+
+func emptySignature() *string {
+	empty := ""
+	return &empty
 }
 
 // reasoningContent extracts the reasoning_content surfaced by providers (e.g.

--- a/internal/anthropicapi/response_test.go
+++ b/internal/anthropicapi/response_test.go
@@ -227,7 +227,8 @@ func TestFromChatResponseStopSequenceDoesNotOverrideToolUse(t *testing.T) {
 // FromChatResponse renders thinking from the replay state a provider attached
 // when it has one, and falls back to plain reasoning_content text otherwise —
 // a provider with no thinking protocol of its own (DeepSeek, Cohere, …) still
-// has its reasoning surfaced, just without a signature to replay.
+// has its reasoning surfaced, with the empty signature the Anthropic schema
+// requires on every thinking block.
 func TestFromChatResponseThinkingBlocks(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -246,7 +247,7 @@ func TestFromChatResponseThinkingBlocks(t *testing.T) {
 		{
 			name:   "reasoning_content alone still renders a thinking block",
 			fields: map[string]json.RawMessage{"reasoning_content": json.RawMessage(`"Let me think."`)},
-			want:   `[{"type":"thinking","thinking":"Let me think."},{"type":"text","text":"Hi"}]`,
+			want:   `[{"type":"thinking","thinking":"Let me think.","signature":""},{"type":"text","text":"Hi"}]`,
 		},
 		{
 			name: "another vendor's replay state is not thinking",
@@ -261,7 +262,7 @@ func TestFromChatResponseThinkingBlocks(t *testing.T) {
 				"reasoning_content":    json.RawMessage(`"Let me think."`),
 				core.ExtraContentField: json.RawMessage(`{"anthropic":{"thinking_blocks":"nope"}}`),
 			},
-			want: `[{"type":"thinking","thinking":"Let me think."},{"type":"text","text":"Hi"}]`,
+			want: `[{"type":"thinking","thinking":"Let me think.","signature":""},{"type":"text","text":"Hi"}]`,
 		},
 	}
 

--- a/internal/anthropicapi/stream.go
+++ b/internal/anthropicapi/stream.go
@@ -237,14 +237,14 @@ func (sc *streamConverter) handleThinkingReplay(raw json.RawMessage) {
 			sc.openBlock("redacted_thinking", map[string]any{"type": "redacted_thinking", "data": block.Data})
 			sc.closeBlock()
 		default:
-			if block.Signature == "" {
+			if block.Signature == nil || *block.Signature == "" {
 				continue
 			}
 			sc.ensureBlock("thinking")
 			sc.emit("content_block_delta", map[string]any{
 				"type":  "content_block_delta",
 				"index": sc.curIndex,
-				"delta": map[string]any{"type": "signature_delta", "signature": block.Signature},
+				"delta": map[string]any{"type": "signature_delta", "signature": *block.Signature},
 			})
 			sc.closeBlock()
 		}
@@ -289,6 +289,10 @@ func (sc *streamConverter) ensureBlock(blockType string) {
 	contentBlock := map[string]any{"type": blockType}
 	if blockType == "thinking" {
 		contentBlock["thinking"] = ""
+		// Anthropic opens a thinking block with an empty signature and fills it
+		// with a signature_delta; a provider that never signs its reasoning
+		// simply leaves it empty, so the block still matches the schema.
+		contentBlock["signature"] = ""
 	} else {
 		contentBlock["text"] = ""
 	}

--- a/internal/anthropicapi/stream_test.go
+++ b/internal/anthropicapi/stream_test.go
@@ -280,6 +280,37 @@ func TestStreamConverterThinkingSignature(t *testing.T) {
 	}
 }
 
+// A provider that reasons without signing its output (DeepSeek, Fireworks, …)
+// still has to produce a schema-valid thinking block: Anthropic opens one with
+// "signature": "" and the gateway must do the same, so a strictly typed client
+// can accumulate the stream. No signature_delta follows, because there is no
+// signature to report.
+func TestStreamConverterUnsignedThinkingCarriesEmptySignature(t *testing.T) {
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"deepseek-flash","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"Let me think."},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	events := drainConverter(t, chatStream)
+	block := events[1]["content_block"].(map[string]any)
+	if events[1]["type"] != "content_block_start" || block["type"] != "thinking" {
+		t.Fatalf("event 1 = %v, want a thinking content_block_start", events[1])
+	}
+	signature, ok := block["signature"]
+	if !ok || signature != "" {
+		t.Fatalf("content_block = %v, want an empty signature member", block)
+	}
+	for _, event := range events {
+		if delta, ok := event["delta"].(map[string]any); ok && delta["type"] == "signature_delta" {
+			t.Fatalf("unsigned reasoning emitted %v, want no signature_delta", delta)
+		}
+	}
+}
+
 // A redacted thinking block has no deltas of its own: it arrives whole, and
 // the converter must open and close a content block for it so the client can
 // replay the opaque payload.

--- a/internal/anthropicapi/types.go
+++ b/internal/anthropicapi/types.go
@@ -122,8 +122,11 @@ type ResponseContentBlock struct {
 	Text     string `json:"text,omitempty"`
 	Thinking string `json:"thinking,omitempty"`
 	// Signature authenticates a thinking block. Anthropic requires it back
-	// verbatim when the conversation continues, so clients must echo it.
-	Signature string `json:"signature,omitempty"`
+	// verbatim when the conversation continues, so clients must echo it. Every
+	// thinking block carries the member, as the Anthropic schema requires;
+	// reasoning from a provider that does not sign its output is rendered with
+	// an empty signature. Hence the pointer: only a thinking block has one.
+	Signature *string `json:"signature,omitempty"`
 	// Data is the opaque payload of a redacted_thinking block.
 	Data  string          `json:"data,omitempty"`
 	ID    string          `json:"id,omitempty"`

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -2125,6 +2125,73 @@ func TestConvertToAnthropicRequest_ReplaysThinkingBlocks(t *testing.T) {
 	}
 }
 
+// Reasoning another provider produced reaches Anthropic as a thinking block
+// with no signature of Anthropic's own. Anthropic rejects the whole request for
+// it ("signature: Field required", or "Invalid `signature`" for anything the
+// gateway could mint), so the block is dropped and the rest of the turn stands.
+func TestConvertToAnthropicRequest_DropsUnsignedThinkingBlocks(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks string
+		want   []string
+	}{
+		{
+			name:   "missing signature",
+			blocks: `[{"type":"thinking","thinking":"foreign"}]`,
+			want:   []string{"text"},
+		},
+		{
+			name:   "empty signature",
+			blocks: `[{"type":"thinking","thinking":"foreign","signature":""}]`,
+			want:   []string{"text"},
+		},
+		{
+			name:   "signed blocks are kept",
+			blocks: `[{"type":"thinking","thinking":"own","signature":"sig1"}]`,
+			want:   []string{"thinking", "text"},
+		},
+		{
+			name:   "redacted blocks carry data rather than a signature",
+			blocks: `[{"type":"redacted_thinking","data":"opaque"}]`,
+			want:   []string{"redacted_thinking", "text"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := convertToAnthropicRequest(&core.ChatRequest{
+				Model: "claude-sonnet-4-5-20250929",
+				Messages: []core.Message{
+					{Role: "user", Content: "hi"},
+					{
+						Role:    "assistant",
+						Content: "391",
+						ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+							core.ExtraContentField: json.RawMessage(`{"anthropic":{"thinking_blocks":` + tt.blocks + `}}`),
+						}),
+					},
+					{Role: "user", Content: "and now?"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest: %v", err)
+			}
+			var got []string
+			switch content := req.Messages[1].Content.(type) {
+			case []anthropicContentBlock:
+				for _, block := range content {
+					got = append(got, block.Type)
+				}
+			case string:
+				got = []string{"text"}
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("assistant blocks = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConvertToAnthropicRequest_RejectsMalformedAnthropicExtraContent(t *testing.T) {
 	_, err := convertToAnthropicRequest(&core.ChatRequest{
 		Model: "claude-sonnet-4-5-20250929",

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -353,7 +353,7 @@ func prependThinkingBlocks(msg core.Message, content any) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	thinking := extra.ThinkingBlocks
+	thinking := signedThinkingBlocks(extra.ThinkingBlocks)
 	if len(thinking) == 0 {
 		return content, nil
 	}
@@ -368,6 +368,24 @@ func prependThinkingBlocks(msg core.Message, content any) (any, error) {
 		blocks = append(blocks, c...)
 	}
 	return blocks, nil
+}
+
+// signedThinkingBlocks keeps the replayed blocks Anthropic can accept back.
+// Anthropic rejects a thinking block whose signature it did not mint — a
+// missing one with "signature: Field required", any other with "Invalid
+// signature" — so reasoning another provider produced (which the Messages
+// dialect surfaces as a thinking block with an empty signature) is dropped
+// here instead of failing the whole turn. Redacted blocks carry opaque data
+// rather than a signature and are always kept.
+func signedThinkingBlocks(blocks []anthropicContentBlock) []anthropicContentBlock {
+	kept := make([]anthropicContentBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == "thinking" && strings.TrimSpace(block.Signature) == "" {
+			continue
+		}
+		kept = append(kept, block)
+	}
+	return kept
 }
 
 // convertToAnthropicRequest converts core.ChatRequest to Anthropic format.

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -192,7 +192,11 @@ func (s *translatedInferenceService) Messages(c *echo.Context) error {
 	recordPromptPluginRevisions(c, s.logger, req, prepared)
 	applyPluginRequestHeaders(c)
 
-	if s.canForwardMessagesNatively(ctx, workflow, anthropicapi.HasUnsignedThinking(decoded)) {
+	// An unsigned thinking block is worth leaving the native path for only when
+	// the translated pipeline can actually carry the request: content it cannot
+	// represent (server-tool history, …) still belongs upstream verbatim.
+	unsignedThinking := translateErr == nil && anthropicapi.HasUnsignedThinking(decoded)
+	if s.canForwardMessagesNatively(ctx, workflow, unsignedThinking) {
 		return s.dispatchMessagesNative(c, prepared, workflow)
 	}
 	if translateErr != nil {

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -192,7 +192,7 @@ func (s *translatedInferenceService) Messages(c *echo.Context) error {
 	recordPromptPluginRevisions(c, s.logger, req, prepared)
 	applyPluginRequestHeaders(c)
 
-	if s.canForwardMessagesNatively(ctx, workflow) {
+	if s.canForwardMessagesNatively(ctx, workflow, anthropicapi.HasUnsignedThinking(decoded)) {
 		return s.dispatchMessagesNative(c, prepared, workflow)
 	}
 	if translateErr != nil {

--- a/internal/server/messages_handler_test.go
+++ b/internal/server/messages_handler_test.go
@@ -257,6 +257,48 @@ func TestMessages_UnsignedThinkingSkipsNativeForwarding(t *testing.T) {
 	}
 }
 
+// Untranslatable content wins over the unsigned-thinking detour: the
+// translated pipeline would reject the request outright, so the body is still
+// forwarded verbatim and Anthropic decides.
+func TestMessages_UnsignedThinkingKeepsNativeForwardingForUntranslatableContent(t *testing.T) {
+	nativeResponse := `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"native"}],"model":"claude-test","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+	provider := &mockProvider{
+		supportedModels: []string{"claude-test"},
+		providerTypes:   map[string]string{"claude-test": "anthropic"},
+		passthroughResponse: &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers:    map[string][]string{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(nativeResponse)),
+		},
+	}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"claude-test","max_tokens":64,"tools":[{"type":"web_search_20250305","name":"web_search"}],"messages":[{"role":"user","content":"search"},` +
+		`{"role":"assistant","content":[{"type":"thinking","thinking":"foreign","signature":""},{"type":"server_tool_use","id":"srv_1","name":"web_search","input":{"query":"q"}},{"type":"web_search_tool_result","tool_use_id":"srv_1","content":[]}]},` +
+		`{"role":"user","content":"and?"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if provider.lastPassthroughReq == nil {
+		t.Fatal("provider did not receive a passthrough request")
+	}
+	forwardedBody, err := io.ReadAll(provider.lastPassthroughReq.Body)
+	if err != nil {
+		t.Fatalf("read forwarded body: %v", err)
+	}
+	if string(forwardedBody) != reqBody {
+		t.Errorf("forwarded body = %s, want original request verbatim", forwardedBody)
+	}
+}
+
 func TestMessages_TranslatedPipelineStillRejectsUntranslatableContent(t *testing.T) {
 	provider := &mockProvider{
 		supportedModels: []string{"gpt-test"},

--- a/internal/server/messages_handler_test.go
+++ b/internal/server/messages_handler_test.go
@@ -221,6 +221,42 @@ func TestMessages_NativeForwardingSurvivesUntranslatableContent(t *testing.T) {
 	}
 }
 
+// A turn produced by another provider replays a thinking block Anthropic never
+// signed. Forwarding it verbatim would fail the request upstream, so the
+// request takes the translated pipeline, which drops the block.
+func TestMessages_UnsignedThinkingSkipsNativeForwarding(t *testing.T) {
+	provider := &mockProvider{
+		supportedModels: []string{"claude-test"},
+		providerTypes:   map[string]string{"claude-test": "anthropic"},
+		response: &core.ChatResponse{
+			ID:      "msg_1",
+			Choices: []core.Choice{{Message: core.ResponseMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"}},
+		},
+	}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"claude-test","max_tokens":64,"messages":[{"role":"user","content":"hi"},` +
+		`{"role":"assistant","content":[{"type":"thinking","thinking":"foreign","signature":""},{"type":"text","text":"391"}]},` +
+		`{"role":"user","content":"and now?"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if provider.lastPassthroughReq != nil {
+		t.Error("request was forwarded natively; Anthropic rejects an unsigned thinking block")
+	}
+	if !strings.Contains(rec.Body.String(), `"text":"ok"`) {
+		t.Errorf("body = %s, want the translated Anthropic envelope", rec.Body.String())
+	}
+}
+
 func TestMessages_TranslatedPipelineStillRejectsUntranslatableContent(t *testing.T) {
 	provider := &mockProvider{
 		supportedModels: []string{"gpt-test"},

--- a/internal/server/messages_native.go
+++ b/internal/server/messages_native.go
@@ -28,9 +28,13 @@ const anthropicProviderType = "anthropic"
 // signatures, anthropic-beta headers), which Claude Code clients depend on.
 // Features that operate on the canonical translated request take precedence:
 // requests using guardrails patching, response caching, or failover stay on
-// the translated pipeline.
-func (s *translatedInferenceService) canForwardMessagesNatively(ctx context.Context, workflow *core.Workflow) bool {
+// the translated pipeline. So does a request replaying an unsigned thinking
+// block, which Anthropic rejects and only the translated pipeline can drop.
+func (s *translatedInferenceService) canForwardMessagesNatively(ctx context.Context, workflow *core.Workflow, unsignedThinking bool) bool {
 	if workflow == nil || strings.TrimSpace(workflow.ProviderType) != anthropicProviderType {
+		return false
+	}
+	if unsignedThinking {
 		return false
 	}
 	if s.translatedRequestPatcher != nil {

--- a/internal/server/plugin_phases_test.go
+++ b/internal/server/plugin_phases_test.go
@@ -286,7 +286,7 @@ func TestCanForwardMessagesNatively_DisabledByPostResponsePlugins(t *testing.T) 
 	chains := phaseChains(t, map[string]string{"response": "warn"}, guardrails.StepReference{Ref: "phase", Phase: pluginapi.KindResponse, Step: 1})
 	svc := &translatedInferenceService{provider: &capturingProvider{}, pluginChains: staticChainsResolver{chains: chains}}
 	workflow := &core.Workflow{ProviderType: anthropicProviderType}
-	if svc.canForwardMessagesNatively(context.Background(), workflow) {
+	if svc.canForwardMessagesNatively(context.Background(), workflow, false) {
 		t.Fatal("native fast path allowed with a response chain")
 	}
 	svc.pluginChains = staticChainsResolver{chains: &plugins.Chains{}}


### PR DESCRIPTION
`thinking` blocks returned by `/v1/messages` for providers that reason without signing their output (DeepSeek, Fireworks, …) omitted `signature` entirely. The Anthropic schema marks the member required on every thinking block, so a strictly typed client can reject the assistant turn before replaying it.

**The contract picked.** The block now carries `signature: ""` — the exact value Anthropic itself streams in `content_block_start` before the real `signature_delta` arrives — and streaming emits no `signature_delta` when there is nothing to sign. A gateway-minted placeholder was ruled out: Anthropic rejects any signature it did not issue (`Invalid \`signature\` in \`thinking\` block`, verified live), so an opaque value would have to be stripped again on the way back in, buying nothing over the empty string. Suppressing the block was ruled out too: it would hide reasoning the client asked for and that its own provider replays happily.

**Consequences on the way back in.** An unsigned block replays to the provider that produced it like any other (the router already drops foreign vendor state). Anthropic refuses it — missing gives `signature: Field required`, empty gives `Invalid signature` — so a history moved onto a Claude model now has the unsigned block dropped before dispatch, and the rest of the turn is sent unchanged. Requests carrying one skip native forwarding for the same reason. Anthropic's own signed blocks are unaffected on both paths.

**Tested** against real providers on `/v1/messages` with thinking enabled — `openai/gpt-5-mini`, `gemini/gemini-3-flash-preview`, `groq/openai/gpt-oss-20b`, `deepseek/deepseek-flash` — streaming and non-streaming, plain 2-turn chat and a tool loop, replaying the assistant turn verbatim each time: 35/35 checks pass. `anthropic-python 0.60.0` now reads `ThinkingBlock.signature == ""` instead of `None`, buffered and streamed. Cross-provider: a DeepSeek turn replayed to `anthropic/claude-haiku-4-5` returned 400 before this change and 200 after; Anthropic's own signed turn still round-trips.

`go build ./...`, `go test -race` on the touched packages, and `make lint` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Reasoning from providers that do not sign their output is now represented with an empty signature in Anthropic-compatible responses, including streaming responses.
  * Unsigned reasoning is preserved when replayed to its originating provider.
  * Unsigned thinking blocks are removed before requests are sent to Anthropic, preventing request failures while preserving the rest of the turn.

* **Documentation**
  * Added guidance describing unsigned reasoning behavior, routing, and signature requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->