### PR TITLE
fix(passthrough): proxy provider-native error bodies, clean decode errors, cap stop sequences

### DIFF
--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -228,7 +228,9 @@ features that have no canonical equivalent are not preserved end to end:
   `stop_reason: "stop_sequence"` plus the `stop_sequence` value. OpenAI-family
   providers conflate stop-parameter hits with natural stops in `finish_reason`,
   so completions there report `stop_reason: "end_turn"` (output is still truncated
-  correctly).
+  correctly). OpenAI, Azure OpenAI, and Groq accept at most four stop sequences;
+  a longer list is truncated to the first four (with a warning in the gateway
+  log) instead of failing the request. Anthropic accepts the full list.
 - **`thinking`** on a non-Anthropic model becomes a reasoning effort (budget
   under 10000 tokens: `low`, under 20000: `medium`, otherwise `high`; adaptive:
   `medium`), sent as each provider's own field: `reasoning_effort` on OpenAI,

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -144,7 +144,10 @@ Passthrough is intentionally narrow while the API is in beta.
   that surface.
 - GoModel does not translate passthrough request bodies or response bodies.
 - Provider-native error bodies and status codes are proxied instead of converted
-  into OpenAI-compatible responses.
+  into OpenAI-compatible responses, so provider SDKs raise their own typed
+  errors. Errors raised by GoModel itself (authentication, rate limits, budgets,
+  a provider that is not enabled, an unreachable upstream) use the gateway's
+  error shape, as does an upstream error body that is not JSON.
 - Features that depend on OpenAI-compatible request or response shapes may not
   apply to passthrough traffic in the same way as `/v1` traffic.
 

--- a/internal/core/chat_json.go
+++ b/internal/core/chat_json.go
@@ -12,7 +12,7 @@ func (r *ChatRequest) UnmarshalJSON(data []byte) error {
 	type alias ChatRequest
 	var raw alias
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+		return wrapJSONDecodeError(err)
 	}
 
 	extraFields, err := extractUnknownJSONFieldsSet(data, chatRequestFields)

--- a/internal/core/json_errors.go
+++ b/internal/core/json_errors.go
@@ -1,0 +1,283 @@
+package core
+
+import (
+	"bytes"
+	// encoding/json rather than goccy: the field locator walks the body with
+	// the standard decoder's token stream and InputOffset.
+	stdjson "encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-json"
+)
+
+// jsonDecodeError carries a nested decode failure out of an UnmarshalJSON
+// method unchanged. goccy/go-json rebuilds the errors it recognizes when they
+// cross a custom unmarshaler, dropping the position that names which member
+// failed; an error type it does not recognize is returned as-is, so the
+// original travels inside this wrapper.
+type jsonDecodeError struct{ err error }
+
+func (e *jsonDecodeError) Error() string { return e.err.Error() }
+
+func (e *jsonDecodeError) Unwrap() error { return e.err }
+
+// wrapJSONDecodeError preserves a decode error raised inside a request type's
+// UnmarshalJSON, so NewInvalidRequestBodyError can still locate the member.
+func wrapJSONDecodeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &jsonDecodeError{err: err}
+}
+
+// NewInvalidRequestBodyError renders a request-body decode failure as a clean
+// client error. Decoder errors are written for Go authors: they name Go types
+// and struct fields, and goccy/go-json reports a type mismatch inside a
+// complete document as "unexpected end of JSON input", which sends users
+// hunting for a truncation that does not exist. This translates the failure
+// into the offending JSON member and the type it should have, and sets that
+// member as the error param so OpenAI-shaped clients can read it.
+func NewInvalidRequestBodyError(body []byte, err error) *GatewayError {
+	detail, param := describeJSONDecodeError(body, err)
+	gatewayErr := NewInvalidRequestError("invalid request body: "+detail, err)
+	if param != "" {
+		return gatewayErr.WithParam(param)
+	}
+	return gatewayErr
+}
+
+// describeJSONDecodeError returns the client-facing description of a decode
+// failure and, when the failure can be attributed to one JSON member, its
+// path (e.g. "messages[0].role").
+func describeJSONDecodeError(body []byte, err error) (detail, param string) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return "request body is empty", ""
+	}
+	if !json.Valid(trimmed) {
+		return describeInvalidJSON(trimmed, err), ""
+	}
+	if trimmed[0] != '{' {
+		return "request body must be a JSON object", ""
+	}
+
+	offset, wanted := decodeMismatch(err)
+	if wanted == "" {
+		return fallbackDecodeDetail(err), ""
+	}
+	path := jsonMemberAtOffset(trimmed, offset)
+	if path == "" {
+		return "a field has the wrong type: expected " + wanted, ""
+	}
+	return path + ": must be " + wanted, path
+}
+
+// describeInvalidJSON describes a body that is not valid JSON at all, without
+// quoting the decoder's internal wording.
+func describeInvalidJSON(trimmed []byte, err error) string {
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || !endsJSONDocument(trimmed) {
+		return "request body is not valid JSON: the document ends unexpectedly"
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) && syntaxErr.Offset > 0 {
+		return "request body is not valid JSON at byte " + strconv.FormatInt(syntaxErr.Offset, 10)
+	}
+	return "request body is not valid JSON"
+}
+
+// endsJSONDocument reports whether the body at least closes its outermost
+// container, which separates a truncated document from a malformed one.
+func endsJSONDocument(trimmed []byte) bool {
+	switch trimmed[0] {
+	case '{':
+		return trimmed[len(trimmed)-1] == '}'
+	case '[':
+		return trimmed[len(trimmed)-1] == ']'
+	default:
+		return true
+	}
+}
+
+// decodeMismatch extracts the position and the expected type of a type
+// mismatch from a decoder error, or wanted == "" when the error is not one.
+// goccy/go-json reports mismatches either as an UnmarshalTypeError or, for
+// several kinds, as a SyntaxError whose message carries the expected kind and
+// whose offset points at the offending value.
+func decodeMismatch(err error) (offset int64, wanted string) {
+	if typeErr, ok := errors.AsType[*json.UnmarshalTypeError](err); ok {
+		return typeErr.Offset, describeGoType(typeErr.Type)
+	}
+	if stdTypeErr, ok := errors.AsType[*stdjson.UnmarshalTypeError](err); ok {
+		return stdTypeErr.Offset, describeGoType(stdTypeErr.Type)
+	}
+	if syntaxErr, ok := errors.AsType[*json.SyntaxError](err); ok {
+		return syntaxErr.Offset, describeDecoderKind(syntaxErr.Error())
+	}
+	return 0, ""
+}
+
+// describeDecoderKind maps goccy's kind-prefixed mismatch messages
+// ("json: slice unexpected end of JSON input", "expected { character for map
+// value") onto a client-facing type name.
+func describeDecoderKind(message string) string {
+	if kind, ok := strings.CutSuffix(strings.TrimPrefix(message, "json: "), " unexpected end of JSON input"); ok {
+		switch {
+		case kind == "slice" || kind == "array":
+			return "an array"
+		case kind == "bool":
+			return "a boolean"
+		case kind == "string":
+			return "a string"
+		case kind == "map" || kind == "struct":
+			return "an object"
+		case strings.HasPrefix(kind, "number(integer)") || kind == "int" || kind == "uint":
+			return "an integer"
+		case kind == "float" || strings.HasPrefix(kind, "number"):
+			return "a number"
+		}
+		return ""
+	}
+	if strings.HasPrefix(message, "expected { character for map value") {
+		return "an object"
+	}
+	return ""
+}
+
+// describeGoType names the JSON type a Go type decodes from.
+func describeGoType(t reflect.Type) string {
+	if t == nil {
+		return ""
+	}
+	switch t.Kind() {
+	case reflect.Bool:
+		return "a boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "an integer"
+	case reflect.Float32, reflect.Float64:
+		return "a number"
+	case reflect.String:
+		return "a string"
+	case reflect.Slice, reflect.Array:
+		return "an array"
+	case reflect.Map, reflect.Struct:
+		return "an object"
+	case reflect.Pointer, reflect.Interface:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// fallbackDecodeDetail keeps a decoder message the translation does not
+// recognize readable: the "json: " prefix is dropped and nothing else is
+// invented.
+func fallbackDecodeDetail(err error) string {
+	if err == nil {
+		return "request body could not be decoded"
+	}
+	return strings.TrimPrefix(err.Error(), "json: ")
+}
+
+// jsonContainer is one open object or array while walking a JSON document:
+// an object tracks the member currently being read, an array its index.
+type jsonContainer struct {
+	key     string
+	index   int
+	isArray bool
+	wantKey bool
+}
+
+// jsonMemberAtOffset returns the path of the JSON member whose value spans
+// offset (e.g. "messages[0].role"), or "" when the position cannot be
+// attributed to one member. The decoders report the mismatching value's
+// position but not its member, so the document is walked to recover it.
+func jsonMemberAtOffset(body []byte, offset int64) string {
+	if offset <= 0 || offset > int64(len(body)) {
+		return ""
+	}
+	var stack []jsonContainer
+	dec := stdjson.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		top := len(stack) - 1
+		switch {
+		case isJSONOpenDelim(tok):
+			if delim, _ := tok.(stdjson.Delim); delim == '{' {
+				stack = append(stack, jsonContainer{wantKey: true})
+			} else {
+				stack = append(stack, jsonContainer{isArray: true})
+			}
+			continue
+		case isJSONCloseDelim(tok):
+			if top < 0 {
+				return ""
+			}
+			stack = stack[:top]
+			endJSONValue(stack)
+		case top >= 0 && stack[top].wantKey:
+			key, _ := tok.(string)
+			stack[top].key = key
+			stack[top].wantKey = false
+		default:
+			endJSONValue(stack)
+		}
+		// goccy reports the offending value's first byte and encoding/json the
+		// byte after its last, so the member is the one whose token stream
+		// first reaches the offset.
+		if dec.InputOffset() >= offset {
+			return jsonMemberPath(stack)
+		}
+	}
+}
+
+func isJSONOpenDelim(tok stdjson.Token) bool {
+	delim, ok := tok.(stdjson.Delim)
+	return ok && (delim == '{' || delim == '[')
+}
+
+func isJSONCloseDelim(tok stdjson.Token) bool {
+	delim, ok := tok.(stdjson.Delim)
+	return ok && (delim == '}' || delim == ']')
+}
+
+// endJSONValue records that the innermost container finished a value: an
+// object expects a key next, an array advances to the next element.
+func endJSONValue(stack []jsonContainer) {
+	top := len(stack) - 1
+	if top < 0 {
+		return
+	}
+	if stack[top].isArray {
+		stack[top].index++
+		return
+	}
+	stack[top].wantKey = true
+}
+
+// jsonMemberPath renders the open containers as a member path.
+func jsonMemberPath(stack []jsonContainer) string {
+	var b strings.Builder
+	for _, container := range stack {
+		if container.isArray {
+			b.WriteString("[" + strconv.Itoa(container.index) + "]")
+			continue
+		}
+		if container.key == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString(".")
+		}
+		b.WriteString(container.key)
+	}
+	return b.String()
+}

--- a/internal/core/json_errors.go
+++ b/internal/core/json_errors.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/goccy/go-json"
+
+	"github.com/tidwall/gjson"
 )
 
 // jsonDecodeError carries a nested decode failure out of an UnmarshalJSON
@@ -32,6 +34,28 @@ func wrapJSONDecodeError(err error) error {
 		return nil
 	}
 	return &jsonDecodeError{err: err}
+}
+
+// jsonMemberDecodeError marks a decode failure raised while decoding a single
+// member's value on its own. Positions inside such an error are relative to
+// that fragment rather than to the request body, so the member is named from
+// the decode site instead of located in the document.
+type jsonMemberDecodeError struct {
+	member string
+	err    error
+}
+
+func (e *jsonMemberDecodeError) Error() string { return e.err.Error() }
+
+func (e *jsonMemberDecodeError) Unwrap() error { return e.err }
+
+// wrapJSONMemberDecodeError attributes a fragment decode failure to the member
+// whose value was being decoded.
+func wrapJSONMemberDecodeError(member string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &jsonMemberDecodeError{member: member, err: err}
 }
 
 // NewInvalidRequestBodyError renders a request-body decode failure as a clean
@@ -65,12 +89,21 @@ func describeJSONDecodeError(body []byte, err error) (detail, param string) {
 		return "request body must be a JSON object", ""
 	}
 
+	// A member decoded on its own reports positions inside its own fragment,
+	// so the member it was decoded for is used instead of a location.
+	if memberErr, ok := errors.AsType[*jsonMemberDecodeError](err); ok {
+		if _, wanted := decodeMismatch(memberErr.err); wanted != "" {
+			return memberErr.member + ": must be " + wanted, memberErr.member
+		}
+		return memberErr.member + ": " + fallbackDecodeDetail(memberErr.err), memberErr.member
+	}
+
 	offset, wanted := decodeMismatch(err)
 	if wanted == "" {
 		return fallbackDecodeDetail(err), ""
 	}
-	path := jsonMemberAtOffset(trimmed, offset)
-	if path == "" {
+	path, lookup := jsonMemberAtOffset(trimmed, offset)
+	if path == "" || !memberValueConflicts(trimmed, lookup, wanted) {
 		return "a field has the wrong type: expected " + wanted, ""
 	}
 	return path + ": must be " + wanted, path
@@ -193,12 +226,13 @@ type jsonContainer struct {
 }
 
 // jsonMemberAtOffset returns the path of the JSON member whose value spans
-// offset (e.g. "messages[0].role"), or "" when the position cannot be
-// attributed to one member. The decoders report the mismatching value's
-// position but not its member, so the document is walked to recover it.
-func jsonMemberAtOffset(body []byte, offset int64) string {
+// offset (e.g. "messages[0].role") plus the gjson lookup path for that member,
+// or "" when the position cannot be attributed to one member. The decoders
+// report the mismatching value's position but not its member, so the document
+// is walked to recover it.
+func jsonMemberAtOffset(body []byte, offset int64) (path, lookup string) {
 	if offset <= 0 || offset > int64(len(body)) {
-		return ""
+		return "", ""
 	}
 	var stack []jsonContainer
 	dec := stdjson.NewDecoder(bytes.NewReader(body))
@@ -206,9 +240,25 @@ func jsonMemberAtOffset(body []byte, offset int64) string {
 	for {
 		tok, err := dec.Token()
 		if err != nil {
-			return ""
+			return "", ""
 		}
 		top := len(stack) - 1
+		isKey := false
+		if top >= 0 && stack[top].wantKey {
+			if key, ok := tok.(string); ok {
+				stack[top].key = key
+				stack[top].wantKey = false
+				isKey = true
+			}
+		}
+		// goccy reports the offending value's first byte and encoding/json the
+		// byte after its last, so the member is the one whose token stream
+		// first reaches the offset. The check runs before a container is
+		// pushed, so a value that is itself an object or array is attributed
+		// to the member holding it.
+		if !isKey && dec.InputOffset() >= offset {
+			return jsonMemberPath(stack)
+		}
 		switch {
 		case isJSONOpenDelim(tok):
 			if delim, _ := tok.(stdjson.Delim); delim == '{' {
@@ -216,26 +266,40 @@ func jsonMemberAtOffset(body []byte, offset int64) string {
 			} else {
 				stack = append(stack, jsonContainer{isArray: true})
 			}
-			continue
 		case isJSONCloseDelim(tok):
 			if top < 0 {
-				return ""
+				return "", ""
 			}
 			stack = stack[:top]
 			endJSONValue(stack)
-		case top >= 0 && stack[top].wantKey:
-			key, _ := tok.(string)
-			stack[top].key = key
-			stack[top].wantKey = false
-		default:
+		case !isKey:
 			endJSONValue(stack)
 		}
-		// goccy reports the offending value's first byte and encoding/json the
-		// byte after its last, so the member is the one whose token stream
-		// first reaches the offset.
-		if dec.InputOffset() >= offset {
-			return jsonMemberPath(stack)
-		}
+	}
+}
+
+// memberValueConflicts reports whether the member found at a decoder position
+// really holds a value of the wrong type. A decoder that reports a position
+// inside a fragment it decoded on its own would otherwise put the blame on an
+// innocent member, so a location that does not conflict is discarded.
+func memberValueConflicts(body []byte, lookup, wanted string) bool {
+	value := gjson.GetBytes(body, lookup)
+	if !value.Exists() {
+		return false
+	}
+	switch wanted {
+	case "an array":
+		return !value.IsArray()
+	case "an object":
+		return !value.IsObject()
+	case "a string":
+		return value.Type != gjson.String
+	case "an integer", "a number":
+		return value.Type != gjson.Number
+	case "a boolean":
+		return value.Type != gjson.True && value.Type != gjson.False
+	default:
+		return false
 	}
 }
 
@@ -263,21 +327,44 @@ func endJSONValue(stack []jsonContainer) {
 	stack[top].wantKey = true
 }
 
-// jsonMemberPath renders the open containers as a member path.
-func jsonMemberPath(stack []jsonContainer) string {
-	var b strings.Builder
+// jsonMemberPath renders the open containers as a member path for the client
+// ("messages[0].role") and as a gjson lookup path ("messages.0.role").
+func jsonMemberPath(stack []jsonContainer) (path, lookup string) {
+	var display, gjsonPath strings.Builder
 	for _, container := range stack {
+		index := strconv.Itoa(container.index)
 		if container.isArray {
-			b.WriteString("[" + strconv.Itoa(container.index) + "]")
+			display.WriteString("[" + index + "]")
+			if gjsonPath.Len() > 0 {
+				gjsonPath.WriteString(".")
+			}
+			gjsonPath.WriteString(index)
 			continue
 		}
 		if container.key == "" {
 			continue
 		}
-		if b.Len() > 0 {
-			b.WriteString(".")
+		if display.Len() > 0 {
+			display.WriteString(".")
 		}
-		b.WriteString(container.key)
+		display.WriteString(container.key)
+		if gjsonPath.Len() > 0 {
+			gjsonPath.WriteString(".")
+		}
+		gjsonPath.WriteString(escapeGJSONKey(container.key))
+	}
+	return display.String(), gjsonPath.String()
+}
+
+// escapeGJSONKey escapes the characters gjson treats as path syntax so a
+// member whose name contains them is still looked up literally.
+func escapeGJSONKey(key string) string {
+	var b strings.Builder
+	for _, r := range key {
+		if strings.ContainsRune(`.*?\|#@`, r) {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
 	}
 	return b.String()
 }

--- a/internal/core/json_errors_test.go
+++ b/internal/core/json_errors_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -54,6 +55,43 @@ func TestNewInvalidRequestBodyErrorNamesMemberOnCanonicalRequests(t *testing.T) 
 				t.Errorf("message = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// The Responses input union is decoded from its own fragment, so its decoder
+// positions mean nothing in the request body: the error must name "input", and
+// never an innocent member that happens to sit at that byte.
+func TestNewInvalidRequestBodyErrorAttributesNestedResponsesInput(t *testing.T) {
+	body := []byte(`{"model":"gpt-4.1-mini","metadata":{"k":"v"},"input":[5]}`)
+	err := json.Unmarshal(body, &ResponsesRequest{})
+	if err == nil {
+		t.Fatal("body decoded without error")
+	}
+	gatewayErr := NewInvalidRequestBodyError(body, err)
+	if gatewayErr.Message != "invalid request body: input: must be an object" {
+		t.Errorf("message = %q, want it to blame input", gatewayErr.Message)
+	}
+	if gatewayErr.Param == nil || *gatewayErr.Param != "input" {
+		t.Errorf("param = %v, want input", gatewayErr.Param)
+	}
+}
+
+// A position landing on a member that already holds the expected type cannot
+// be the one that failed — it comes from a fragment the decoder handled on its
+// own — so the error must not be pinned on that member.
+func TestDescribeJSONDecodeErrorDiscardsMisleadingPositions(t *testing.T) {
+	body := []byte(`{"model":"gpt-4.1-mini","messages":[{"role":"user"}]}`)
+	// An offset inside "messages", which is already the array the decoder wanted.
+	detail, param := describeJSONDecodeError(body, &json.UnmarshalTypeError{
+		Value:  "string",
+		Type:   reflect.TypeOf([]string{}),
+		Offset: 35,
+	})
+	if detail != "a field has the wrong type: expected an array" {
+		t.Errorf("detail = %q, want the unattributed message", detail)
+	}
+	if param != "" {
+		t.Errorf("param = %q, want empty", param)
 	}
 }
 

--- a/internal/core/json_errors_test.go
+++ b/internal/core/json_errors_test.go
@@ -1,0 +1,156 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+type decodeTestMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+type decodeTestRequest struct {
+	Model     string                 `json:"model"`
+	MaxTokens int                    `json:"max_tokens"`
+	Messages  []decodeTestMessage    `json:"messages"`
+	Stream    bool                   `json:"stream"`
+	Metadata  map[string]any         `json:"metadata"`
+	TopP      float64                `json:"top_p"`
+	Extra     map[string]json.Number `json:"extra"`
+}
+
+// The canonical request types decode through their own UnmarshalJSON, which
+// used to cost the error its position and with it the member's name.
+func TestNewInvalidRequestBodyErrorNamesMemberOnCanonicalRequests(t *testing.T) {
+	cases := []struct {
+		name   string
+		body   string
+		decode func([]byte) error
+		want   string
+	}{
+		{
+			name:   "chat completions",
+			body:   `{"model":"gpt-4.1-mini","messages":"hi"}`,
+			decode: func(body []byte) error { return json.Unmarshal(body, &ChatRequest{}) },
+			want:   "invalid request body: messages: must be an array",
+		},
+		{
+			name:   "responses",
+			body:   `{"model":"gpt-4.1-mini","input":"hi","temperature":"warm"}`,
+			decode: func(body []byte) error { return json.Unmarshal(body, &ResponsesRequest{}) },
+			want:   "invalid request body: temperature: must be a number",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.decode([]byte(tc.body))
+			if err == nil {
+				t.Fatalf("body %q decoded without error", tc.body)
+			}
+			if got := NewInvalidRequestBodyError([]byte(tc.body), err).Message; got != tc.want {
+				t.Errorf("message = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Decoder wording must never reach the client: goccy reports a type mismatch
+// inside a complete document as "unexpected end of JSON input" and names Go
+// types and struct fields. Each case decodes for real, so the expectations
+// track the decoder the gateway actually uses.
+func TestNewInvalidRequestBodyError(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		message   string
+		param     string
+		unwantSub string
+	}{
+		{
+			name:    "array where object expected",
+			body:    `{"model":"m","messages":"hi"}`,
+			message: "invalid request body: messages: must be an array",
+			param:   "messages",
+		},
+		{
+			name:    "string where integer expected",
+			body:    `{"model":"m","max_tokens":"10"}`,
+			message: "invalid request body: max_tokens: must be an integer",
+			param:   "max_tokens",
+		},
+		{
+			name:    "string where boolean expected",
+			body:    `{"model":"m","stream":"yes"}`,
+			message: "invalid request body: stream: must be a boolean",
+			param:   "stream",
+		},
+		{
+			name:    "string where object expected",
+			body:    `{"model":"m","metadata":"abc"}`,
+			message: "invalid request body: metadata: must be an object",
+			param:   "metadata",
+		},
+		{
+			name:    "string where number expected",
+			body:    `{"model":"m","top_p":"x"}`,
+			message: "invalid request body: top_p: must be a number",
+			param:   "top_p",
+		},
+		{
+			name:    "number where string expected",
+			body:    `{"model":5}`,
+			message: "invalid request body: model: must be a string",
+			param:   "model",
+		},
+		{
+			name:    "nested member is named with its index",
+			body:    `{"messages":[{"role":"user"},{"role":5}]}`,
+			message: "invalid request body: messages[1].role: must be a string",
+			param:   "messages[1].role",
+		},
+		{
+			name:    "truncated body",
+			body:    `{"model":"m","max_tokens":1`,
+			message: "invalid request body: request body is not valid JSON: the document ends unexpectedly",
+		},
+		{
+			name:    "empty body",
+			body:    "",
+			message: "invalid request body: request body is empty",
+		},
+		{
+			name:    "top-level array",
+			body:    `[1,2,3]`,
+			message: "invalid request body: request body must be a JSON object",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req decodeTestRequest
+			err := json.Unmarshal([]byte(tc.body), &req)
+			if err == nil {
+				t.Fatalf("body %q decoded without error", tc.body)
+			}
+			gatewayErr := NewInvalidRequestBodyError([]byte(tc.body), err)
+			if gatewayErr.Message != tc.message {
+				t.Errorf("message = %q, want %q", gatewayErr.Message, tc.message)
+			}
+			param := ""
+			if gatewayErr.Param != nil {
+				param = *gatewayErr.Param
+			}
+			if param != tc.param {
+				t.Errorf("param = %q, want %q", param, tc.param)
+			}
+			for _, leak := range []string{"json:", "Go struct field", "unexpected end of JSON input", "goccy"} {
+				if strings.Contains(gatewayErr.Message, leak) {
+					t.Errorf("message %q leaks decoder internals %q", gatewayErr.Message, leak)
+				}
+			}
+		})
+	}
+}

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -26,7 +26,9 @@ func responsesExtrasAndInput(data []byte, rawInput json.RawMessage, knownFields 
 	}
 	input, err := decodeResponsesInput(rawInput)
 	if err != nil {
-		return nil, UnknownJSONFields{}, err
+		// The input union is decoded from its own fragment, so the failure
+		// carries no position within the request body: name the member here.
+		return nil, UnknownJSONFields{}, wrapJSONMemberDecodeError("input", err)
 	}
 	return input, extraFields, nil
 }

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -43,7 +43,7 @@ func (r *ResponsesRequest) UnmarshalJSON(data []byte) error {
 		Input json.RawMessage `json:"input"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+		return wrapJSONDecodeError(err)
 	}
 	input, extraFields, err := responsesExtrasAndInput(data, raw.Input, responsesRequestFields)
 	if err != nil {

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -38,9 +38,10 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 	// All three clients share opts.Keys, so the rotation is even across them.
 	p := &Provider{apiVersion: apiVersion, keys: opts.Keyring(providerCfg.APIKey)}
 	clientCfg := openai.CompatibleProviderConfig{
-		ProviderName: "azure",
-		BaseURL:      baseURL,
-		SetHeaders:   setHeaders,
+		ProviderName:     "azure",
+		BaseURL:          baseURL,
+		SetHeaders:       setHeaders,
+		AdaptChatRequest: adaptChatRequest,
 	}
 	p.CompatibleProvider = openai.NewCompatibleProvider(providerCfg.APIKey, opts, clientCfg)
 	p.resourceProvider = openai.NewCompatibleProvider(providerCfg.APIKey, opts, clientCfg)
@@ -55,9 +56,10 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
 	p := &Provider{apiVersion: defaultAPIVersion, keys: providers.NewKeyring(apiKey)}
 	cfg := openai.CompatibleProviderConfig{
-		ProviderName: "azure",
-		BaseURL:      "https://example.invalid",
-		SetHeaders:   setHeaders,
+		ProviderName:     "azure",
+		BaseURL:          "https://example.invalid",
+		SetHeaders:       setHeaders,
+		AdaptChatRequest: adaptChatRequest,
 	}
 	p.CompatibleProvider = openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, cfg)
 	p.resourceProvider = openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, cfg)
@@ -160,6 +162,17 @@ func (p *Provider) mutateRequest(req *llmclient.Request) {
 	query.Set("api-version", p.apiVersion)
 	endpoint.RawQuery = query.Encode()
 	req.Endpoint = endpoint.String()
+}
+
+// maxStopSequences is the longest "stop" list Azure OpenAI accepts, the same
+// four-item limit as OpenAI's own chat completions.
+const maxStopSequences = 4
+
+// adaptChatRequest truncates an over-long "stop" list so a request carrying
+// more stop sequences than Azure allows (Anthropic's Messages API accepts
+// more) still reaches the model instead of failing upstream.
+func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
+	return providers.CapStopSequences(req, maxStopSequences)
 }
 
 func setHeaders(req *http.Request, apiKey string) {

--- a/internal/providers/groq/reasoning.go
+++ b/internal/providers/groq/reasoning.go
@@ -8,19 +8,28 @@ import (
 	"github.com/enterpilot/gomodel/internal/providers"
 )
 
-// adaptChatRequest maps GoModel's nested reasoning shape (set by the Messages
-// API's thinking and by clients sending reasoning.effort) onto Groq's flat
-// reasoning_effort. Groq rejects "reasoning" outright and accepts
+// maxStopSequences is the longest "stop" list Groq accepts; a longer one is
+// rejected with "maximum number of items is 4".
+const maxStopSequences = 4
+
+// adaptChatRequest fits the canonical chat request to Groq: it truncates an
+// over-long "stop" list and maps GoModel's nested reasoning shape (set by the
+// Messages API's thinking and by clients sending reasoning.effort) onto Groq's
+// flat reasoning_effort. Groq rejects "reasoning" outright and accepts
 // reasoning_effort only on reasoning models, with per-family values.
 func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
-	if req == nil || req.Reasoning == nil {
-		return req, nil
+	adapted, err := providers.CapStopSequences(req, maxStopSequences)
+	if err != nil {
+		return nil, err
 	}
-	effort := reasoningEffort(req.Model, req.Reasoning.Effort)
+	if adapted == nil || adapted.Reasoning == nil {
+		return adapted, nil
+	}
+	effort := reasoningEffort(adapted.Model, adapted.Reasoning.Effort)
 	if effort == "" {
-		return providers.DropReasoning(req), nil
+		return providers.DropReasoning(adapted), nil
 	}
-	return providers.AdaptReasoningEffortRequest(req, effort)
+	return providers.AdaptReasoningEffortRequest(adapted, effort)
 }
 
 // reasoningEffort returns the reasoning_effort value the model accepts, or ""

--- a/internal/providers/groq/reasoning_test.go
+++ b/internal/providers/groq/reasoning_test.go
@@ -66,3 +66,40 @@ func TestChatCompletion_MapsReasoningPerModelFamily(t *testing.T) {
 		})
 	}
 }
+
+// Groq rejects more than four stop sequences; the Messages API accepts more,
+// so the list is truncated instead of failing the request upstream.
+func TestChatCompletion_CapsStopSequences(t *testing.T) {
+	var raw map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"c1","object":"chat.completion","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	extra, err := core.MergeUnknownJSONFields(core.UnknownJSONFields{}, map[string]json.RawMessage{
+		"stop": json.RawMessage(`["a","b","c","d","e","f"]`),
+	})
+	if err != nil {
+		t.Fatalf("MergeUnknownJSONFields: %v", err)
+	}
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:       "openai/gpt-oss-20b",
+		Messages:    []core.Message{{Role: "user", Content: "hi"}},
+		ExtraFields: extra,
+	}); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	stop, _ := raw["stop"].([]any)
+	if len(stop) != maxStopSequences {
+		t.Fatalf("stop = %v, want %d entries", raw["stop"], maxStopSequences)
+	}
+	if stop[0] != "a" || stop[3] != "d" {
+		t.Errorf("stop = %v, want the first four sequences", stop)
+	}
+}

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -131,19 +131,30 @@ func isNonReasoningChatModel(model string) bool {
 	return strings.HasPrefix(m, "gpt-3.5") || strings.HasPrefix(m, "gpt-4") || strings.HasPrefix(m, "chatgpt-")
 }
 
-// adaptChatRequest maps GoModel's nested reasoning shape (set by the Messages
-// API's thinking and by clients sending reasoning.effort) onto the flat
-// reasoning_effort field: OpenAI Chat Completions rejects "reasoning".
-// Models that cannot reason reject reasoning_effort too, so it is dropped.
+// maxStopSequences is the longest "stop" list OpenAI Chat Completions accepts;
+// a longer one is rejected with "array too long".
+const maxStopSequences = 4
+
+// adaptChatRequest fits the canonical chat request to OpenAI Chat Completions:
+// it truncates an over-long "stop" list (clients coming from the Messages API
+// may send more) and maps GoModel's nested reasoning shape (set by the
+// Messages API's thinking and by clients sending reasoning.effort) onto the
+// flat reasoning_effort field, since OpenAI Chat Completions rejects
+// "reasoning". Models that cannot reason reject reasoning_effort too, so it is
+// dropped for them.
 func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
-	if req == nil || req.Reasoning == nil {
-		return req, nil
+	adapted, err := providers.CapStopSequences(req, maxStopSequences)
+	if err != nil {
+		return nil, err
 	}
-	effort := strings.TrimSpace(req.Reasoning.Effort)
-	if effort == "" || isNonReasoningChatModel(req.Model) {
-		return providers.DropReasoning(req), nil
+	if adapted == nil || adapted.Reasoning == nil {
+		return adapted, nil
 	}
-	return providers.AdaptReasoningEffortRequest(req, effort)
+	effort := strings.TrimSpace(adapted.Reasoning.Effort)
+	if effort == "" || isNonReasoningChatModel(adapted.Model) {
+		return providers.DropReasoning(adapted), nil
+	}
+	return providers.AdaptReasoningEffortRequest(adapted, effort)
 }
 
 // chatRequestBody returns the appropriate request body for the model.

--- a/internal/providers/stop_sequences.go
+++ b/internal/providers/stop_sequences.go
@@ -1,0 +1,50 @@
+package providers
+
+import (
+	"log/slog"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// CapStopSequences returns req with its "stop" list truncated to limit entries.
+// Clients may legitimately send more: Anthropic's Messages API accepts a long
+// stop_sequences list, and the gateway maps it onto the chat "stop" field, but
+// OpenAI-family chat APIs reject a list longer than four outright. Truncating
+// keeps the request working on every provider (Postel's law) instead of
+// failing it upstream over a field the client cannot know the limit of. The
+// dropped sequences are logged so the behavior is visible to operators.
+//
+// The request is shallow-copied like the other request adapters; a "stop"
+// value that is absent, a bare string, or already short enough is left alone.
+func CapStopSequences(req *core.ChatRequest, limit int) (*core.ChatRequest, error) {
+	if req == nil || limit <= 0 {
+		return req, nil
+	}
+	raw := req.ExtraFields.Lookup("stop")
+	if len(raw) == 0 {
+		return req, nil
+	}
+	var sequences []json.RawMessage
+	if err := json.Unmarshal(raw, &sequences); err != nil || len(sequences) <= limit {
+		// Not a list (a bare string is valid too) or within the limit: the
+		// upstream decides. A malformed value is reported by the provider.
+		return req, nil
+	}
+
+	capped, err := json.Marshal(sequences[:limit])
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt stop sequences: "+err.Error(), err)
+	}
+	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{"stop": capped})
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt stop sequences: "+err.Error(), err)
+	}
+	slog.Warn("truncated stop sequences to the provider limit",
+		"model", req.Model, "limit", limit, "requested", len(sequences))
+
+	adapted := *req
+	adapted.ExtraFields = extra
+	return &adapted, nil
+}

--- a/internal/providers/stop_sequences_test.go
+++ b/internal/providers/stop_sequences_test.go
@@ -1,0 +1,67 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// A client cannot know each provider's stop-sequence limit, so an over-long
+// list is truncated rather than rejected upstream. Everything else about the
+// request, including other extra fields, must survive untouched.
+func TestCapStopSequences(t *testing.T) {
+	cases := []struct {
+		name  string
+		stop  string
+		limit int
+		want  string
+	}{
+		{name: "within the limit", stop: `["a","b"]`, limit: 4, want: `["a","b"]`},
+		{name: "at the limit", stop: `["a","b","c","d"]`, limit: 4, want: `["a","b","c","d"]`},
+		{name: "over the limit", stop: `["a","b","c","d","e","f"]`, limit: 4, want: `["a","b","c","d"]`},
+		{name: "bare string", stop: `"a"`, limit: 4, want: `"a"`},
+		{name: "no limit", stop: `["a","b","c","d","e"]`, limit: 0, want: `["a","b","c","d","e"]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			extra, err := core.MergeUnknownJSONFields(core.UnknownJSONFields{}, map[string]json.RawMessage{
+				"stop": json.RawMessage(tc.stop),
+				"seed": json.RawMessage("7"),
+			})
+			if err != nil {
+				t.Fatalf("MergeUnknownJSONFields: %v", err)
+			}
+			req := &core.ChatRequest{Model: "gpt-4.1-mini", ExtraFields: extra}
+
+			adapted, err := CapStopSequences(req, tc.limit)
+			if err != nil {
+				t.Fatalf("CapStopSequences: %v", err)
+			}
+			if got := string(adapted.ExtraFields.Lookup("stop")); got != tc.want {
+				t.Errorf("stop = %s, want %s", got, tc.want)
+			}
+			if got := string(adapted.ExtraFields.Lookup("seed")); got != "7" {
+				t.Errorf("seed = %s, want 7", got)
+			}
+			if got := string(req.ExtraFields.Lookup("stop")); got != tc.stop {
+				t.Errorf("original request mutated: stop = %s, want %s", got, tc.stop)
+			}
+		})
+	}
+}
+
+func TestCapStopSequencesWithoutStopField(t *testing.T) {
+	req := &core.ChatRequest{Model: "gpt-4.1-mini"}
+	adapted, err := CapStopSequences(req, 4)
+	if err != nil {
+		t.Fatalf("CapStopSequences: %v", err)
+	}
+	if adapted != req {
+		t.Fatal("request without a stop field should be returned unchanged")
+	}
+	if adapted, err = CapStopSequences(nil, 4); err != nil || adapted != nil {
+		t.Fatalf("CapStopSequences(nil) = (%v, %v), want (nil, nil)", adapted, err)
+	}
+}

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -55,7 +55,7 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 
 	req, err := canonicalJSONRequestFromSemantics[*core.AudioSpeechRequest](c, core.DecodeAudioSpeechRequest)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	if strings.TrimSpace(req.Input) == "" {
 		return handleError(c, core.NewInvalidRequestError("input is required", nil))

--- a/internal/server/error_support.go
+++ b/internal/server/error_support.go
@@ -141,6 +141,18 @@ func requestDialect(c *echo.Context) string {
 	return core.DescribeEndpointPath(c.Request().URL.Path).Dialect
 }
 
+// invalidRequestBodyError renders a request-body decode failure for the client.
+// The JSON decoder's own wording names Go types and struct fields and, inside a
+// complete document, reports a type mismatch as an unexpected end of input, so
+// the body is re-read to name the offending member instead.
+func invalidRequestBodyError(c *echo.Context, err error) *core.GatewayError {
+	body, readErr := requestBodyBytes(c)
+	if readErr != nil {
+		return core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
+	}
+	return core.NewInvalidRequestBodyError(body, err)
+}
+
 type responseHeaderError interface {
 	ResponseHeaders() http.Header
 }

--- a/internal/server/image_service.go
+++ b/internal/server/image_service.go
@@ -54,7 +54,7 @@ func (s *imageService) CreateImage(c *echo.Context) error {
 	}
 	req, err := core.DecodeImageGenerationRequest(body, env)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	if err := core.ValidateImageGenerationRequest(req); err != nil {
 		return handleError(c, err)

--- a/internal/server/messages_batch_service.go
+++ b/internal/server/messages_batch_service.go
@@ -22,7 +22,7 @@ func (s *nativeBatchService) CreateMessageBatch(c *echo.Context) error {
 	}
 	createReq, err := anthropicapi.DecodeBatchCreateRequest(body)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	req, err := anthropicapi.ToBatchRequest(createReq)
 	if err != nil {

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -213,7 +213,7 @@ func (s *translatedInferenceService) CountMessageTokens(c *echo.Context) error {
 	}
 	req, err := anthropicapi.DecodeMessagesRequest(body)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	if strings.TrimSpace(req.Model) == "" {
 		return handleError(c, core.NewInvalidRequestError("model is required", nil).WithParam("model"))
@@ -309,7 +309,7 @@ func decodeMessagesRequest(c *echo.Context) (*anthropicapi.MessagesRequest, erro
 	}
 	req, err := anthropicapi.DecodeMessagesRequest(body)
 	if err != nil {
-		return nil, core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
+		return nil, invalidRequestBodyError(c, err)
 	}
 	return req, nil
 }

--- a/internal/server/messages_native.go
+++ b/internal/server/messages_native.go
@@ -64,7 +64,7 @@ func (s *translatedInferenceService) dispatchMessagesNative(c *echo.Context, req
 	}
 	body, err = rewriteMessagesModel(body, req.Model)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 
 	s.observeLiveProviderAttempts(c, workflow)

--- a/internal/server/native_batch_service.go
+++ b/internal/server/native_batch_service.go
@@ -58,7 +58,7 @@ func (s *nativeBatchService) batch() *gateway.BatchOrchestrator {
 func (s *nativeBatchService) Batches(c *echo.Context) error {
 	req, err := canonicalJSONRequestFromSemantics[*core.BatchRequest](c, core.DecodeBatchRequest)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 
 	ctx, requestID := requestContextWithRequestID(c.Request())

--- a/internal/server/native_conversation_items_service.go
+++ b/internal/server/native_conversation_items_service.go
@@ -26,7 +26,7 @@ func (s *conversationService) CreateConversationItems(c *echo.Context) error {
 	}
 	req, err := core.DecodeConversationItemCreateRequest(body)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	if len(req.Items) == 0 {
 		return handleError(c, core.NewInvalidRequestError("items is required", nil).WithParam("items"))

--- a/internal/server/native_conversation_service.go
+++ b/internal/server/native_conversation_service.go
@@ -38,7 +38,7 @@ func (s *conversationService) CreateConversation(c *echo.Context) error {
 	}
 	req, err := core.DecodeConversationCreateRequest(body)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	if len(req.Items) > core.MaxConversationInitialItems {
 		return handleError(c, core.NewInvalidRequestError(
@@ -105,7 +105,7 @@ func (s *conversationService) UpdateConversation(c *echo.Context) error {
 	}
 	req, err := core.DecodeConversationUpdateRequest(body)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 	if req.Metadata == nil {
 		return handleError(c, core.NewInvalidRequestError("metadata is required", nil).WithParam("metadata"))

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -263,7 +263,7 @@ func (s *nativeResponseService) CompactResponse(c *echo.Context) error {
 func (s *nativeResponseService) utilityRequest(c *echo.Context) (*core.ResponsesRequest, string, error) {
 	req, err := canonicalJSONRequestFromSemantics[*core.ResponsesRequest](c, core.DecodeResponsesRequest)
 	if err != nil {
-		return nil, "", core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
+		return nil, "", invalidRequestBodyError(c, err)
 	}
 	if req == nil {
 		return nil, "", core.NewInvalidRequestError("responses request body is required", errors.New("responses request body is null"))

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -271,16 +271,7 @@ func proxyPassthroughResponse(c *echo.Context, logger auditlog.LoggerInterface, 
 	}()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return handleError(c, core.NewProviderError(providerType, http.StatusBadGateway, "failed to read provider passthrough error response", err))
-		}
-		gatewayErr := core.ParseProviderError(providerType, resp.StatusCode, body, nil)
-		headers := passthroughErrorResponseHeaders(providerType, resp.StatusCode, http.Header(resp.Headers))
-		if len(headers) == 0 {
-			return handleError(c, gatewayErr)
-		}
-		return handleError(c, &gatewayErrorWithResponseHeaders{GatewayError: gatewayErr, headers: headers})
+		return relayPassthroughError(c, providerType, resp)
 	}
 
 	copyPassthroughResponseHeaders(c.Response().Header(), http.Header(resp.Headers))
@@ -375,6 +366,90 @@ func proxyPassthroughResponse(c *echo.Context, logger auditlog.LoggerInterface, 
 		notifyObserversWithJSONBody(body, observers)
 	}
 	return nil
+}
+
+// maxRelayedPassthroughErrorBytes caps the provider-native error body relayed
+// verbatim. Provider error payloads are small; anything larger is answered
+// with the gateway's own envelope rather than buffered.
+const maxRelayedPassthroughErrorBytes = 1 << 20
+
+// relayPassthroughError answers a non-2xx passthrough response with the
+// provider's own error body, status and content type. That is the documented
+// passthrough contract: provider SDKs parse their native error envelope
+// (Anthropic's {"type":"error",...} with its request_id) and lose their typed
+// errors when the gateway rewrites it into the OpenAI envelope.
+//
+// Only the upstream's own failures reach here. Gateway-generated errors —
+// authentication, rate limits, budgets, unknown or disabled providers,
+// transport failures — are rendered by handleError before or instead of this
+// relay, so they keep the gateway's shape. Nothing but the body, its media
+// type and the small set of headers the gateway already relays on errors
+// crosses back, so upstream credentials, cookies and base URLs cannot leak.
+//
+// Bodies that are not a JSON payload within the cap (an intermediary's HTML
+// error page, for example) fall back to the gateway envelope, so a client
+// always receives a parseable error.
+func relayPassthroughError(c *echo.Context, providerType string, resp *core.PassthroughResponse) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRelayedPassthroughErrorBytes+1))
+	if err != nil {
+		return handleError(c, core.NewProviderError(providerType, http.StatusBadGateway, "failed to read provider passthrough error response", err))
+	}
+	gatewayErr := core.ParseProviderError(providerType, resp.StatusCode, body, nil)
+	headers := passthroughErrorResponseHeaders(providerType, resp.StatusCode, http.Header(resp.Headers))
+	if !isRelayablePassthroughErrorBody(body, resp.Headers) {
+		if len(headers) == 0 {
+			return handleError(c, gatewayErr)
+		}
+		return handleError(c, &gatewayErrorWithResponseHeaders{GatewayError: gatewayErr, headers: headers})
+	}
+
+	// The client receives the provider body; logs and the audit row still carry
+	// the classified gateway error, exactly as handleError would record it.
+	logHandledError(c, gatewayErr)
+	enrichAuditEntryWithProviderAttempts(c)
+	auditlog.EnrichEntryWithGatewayError(c, gatewayErr)
+
+	for key, values := range headers {
+		for _, value := range values {
+			c.Response().Header().Add(key, value)
+		}
+	}
+	c.Response().Header().Set("Content-Type", passthroughErrorContentType(resp.Headers))
+	c.Response().WriteHeader(resp.StatusCode)
+	if _, err := c.Response().Write(body); err != nil {
+		return err
+	}
+	if f, ok := c.Response().(http.Flusher); ok {
+		f.Flush()
+	}
+	return nil
+}
+
+// isRelayablePassthroughErrorBody reports whether an upstream error body can be
+// relayed to the client untouched: a non-empty, valid JSON document served
+// with a JSON content type and small enough to buffer.
+func isRelayablePassthroughErrorBody(body []byte, headers map[string][]string) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || len(body) > maxRelayedPassthroughErrorBytes {
+		return false
+	}
+	return isJSONContentType(headers) && json.Valid(trimmed)
+}
+
+// passthroughErrorContentType returns the upstream JSON media type to relay
+// with an error body, defaulting to application/json.
+func passthroughErrorContentType(headers map[string][]string) string {
+	for key, values := range headers {
+		if !strings.EqualFold(key, "Content-Type") {
+			continue
+		}
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" && !strings.ContainsAny(value, "\r\n") {
+				return value
+			}
+		}
+	}
+	return "application/json"
 }
 
 // maxObservedJSONResponseBytes caps how much of a non-streaming JSON response

--- a/internal/server/passthrough_support_test.go
+++ b/internal/server/passthrough_support_test.go
@@ -156,3 +156,84 @@ func TestProxyPassthroughNonStreamingSkipsNonAccountableResponses(t *testing.T) 
 		})
 	}
 }
+
+// The passthrough contract proxies provider-native error bodies: the Anthropic
+// SDK parses {"type":"error",...} and loses its typed errors — and the
+// request_id — when the gateway rewrites the body into the OpenAI envelope.
+func TestProxyPassthroughRelaysProviderErrorBody(t *testing.T) {
+	body := `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: Field required"},"request_id":"req_011CexSaBK"}`
+	resp := &core.PassthroughResponse{
+		StatusCode: http.StatusBadRequest,
+		Headers: map[string][]string{
+			"Content-Type": {"application/json"},
+			"X-Upstream":   {"must-not-leak"},
+			"Set-Cookie":   {"session=secret"},
+		},
+		Body: io.NopCloser(strings.NewReader(body)),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/p/anthropic/messages", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	info := &core.PassthroughRouteInfo{Provider: "anthropic", RawEndpoint: "messages"}
+	if err := proxyPassthroughResponse(c, nil, nil, nil, "anthropic", "anthropic", "messages", info, resp); err != nil {
+		t.Fatalf("proxyPassthroughResponse: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if rec.Body.String() != body {
+		t.Fatalf("error body not relayed verbatim: %s", rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	for _, header := range []string{"X-Upstream", "Set-Cookie"} {
+		if got := rec.Header().Get(header); got != "" {
+			t.Errorf("%s should not be relayed, got %q", header, got)
+		}
+	}
+}
+
+// A provider error body the gateway cannot hand over as-is (an intermediary's
+// HTML page, an empty body, an oversized payload) still has to reach the
+// client as a parseable gateway error.
+func TestProxyPassthroughConvertsUnrelayableErrorBody(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		body        string
+	}{
+		{name: "HTML error page", contentType: "text/html", body: "<html>502</html>"},
+		{name: "empty body", contentType: "application/json", body: ""},
+		{name: "invalid JSON", contentType: "application/json", body: "{"},
+		{name: "oversized body", contentType: "application/json", body: `{"error":"` + strings.Repeat("x", maxRelayedPassthroughErrorBytes) + `"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &core.PassthroughResponse{
+				StatusCode: http.StatusBadGateway,
+				Headers:    map[string][]string{"Content-Type": {tc.contentType}},
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/p/anthropic/messages", strings.NewReader(`{}`))
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			info := &core.PassthroughRouteInfo{Provider: "anthropic", RawEndpoint: "messages"}
+			if err := proxyPassthroughResponse(c, nil, nil, nil, "anthropic", "anthropic", "messages", info, resp); err != nil {
+				t.Fatalf("proxyPassthroughResponse: %v", err)
+			}
+			if rec.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+			}
+			if !strings.Contains(rec.Body.String(), `"error"`) {
+				t.Fatalf("body is not a gateway error envelope: %s", rec.Body.String())
+			}
+		})
+	}
+}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -200,7 +200,7 @@ func handleTranslatedJSON[Req any](
 ) error {
 	req, err := canonicalJSONRequestFromSemantics[Req](c, decode)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 
 	ctx, preparedReq, workflow, err := prepare(s, promptEditCaptureContext(c, s.logger), req, translatedRequestMeta(c))
@@ -573,7 +573,7 @@ func (s *translatedInferenceService) recordResponseSnapshotStoreFailure(rec snap
 func (s *translatedInferenceService) Embeddings(c *echo.Context) error {
 	req, err := canonicalJSONRequestFromSemantics[*core.EmbeddingRequest](c, core.DecodeEmbeddingRequest)
 	if err != nil {
-		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+		return handleError(c, invalidRequestBodyError(c, err))
 	}
 
 	prepared, err := s.inference().PrepareEmbeddingRequest(c.Request().Context(), req, translatedRequestMeta(c))


### PR DESCRIPTION
Fixes three findings from the dialect e2e run (4, 7, 10), each verified against `main` first.

**Passthrough errors are provider-native again (finding 4).** `docs/features/passthrough-api.mdx` promises that provider error bodies and status codes are proxied, but every non-2xx was re-rendered in the gateway's OpenAI envelope, so the Anthropic SDK lost its typed errors and the upstream `request_id`. `/p/{provider}` (and the `/v1/messages` native-forwarding path) now relay the upstream JSON error body, status and content type untouched. Gateway-generated failures — authentication, rate limits, budgets, a provider that is not enabled, an unreachable upstream — keep the gateway's shape, as does an upstream body that is not JSON, is empty, or exceeds 1 MiB. Only the body, its media type and the headers the gateway already relayed on errors cross back, so upstream credentials, cookies and base URLs still cannot leak. Logs and the audit row keep the classified gateway error.

**Clean JSON decode errors (finding 7).** `goccy/go-json` wording reached clients verbatim: `json: slice unexpected end of JSON input` for a complete document, `cannot unmarshal number \"` for a string value, plus Go struct field names. Decode failures now name the offending member and the type it should have — `messages: must be an array`, `max_tokens: must be an integer`, `messages[1].role: must be a string` — with the member set as `param` on the OpenAI envelope. Truncated and non-JSON bodies get an honest message instead of a byte-level decoder complaint. The canonical chat/responses types wrap the nested decode error so the position that identifies the member survives their `UnmarshalJSON`.

**`stop_sequences` beyond four (finding 10).** OpenAI, Azure OpenAI and Groq cap `stop` at four items; Anthropic accepts more, and the Messages API docs say stop sequences are honored on every provider. Following Postel's law the gateway now truncates the list to each provider's limit (logging a warning) instead of letting the request fail upstream over a limit the client cannot know; Anthropic still receives the full list. The Messages API doc records the limit.

**Tested**

- `go build ./...`, `go test -race ./internal/...`, `make lint`, `make test-race` (only the pre-existing `TestVersionEndpoint*` local/UTC date flake fails).
- Live gateway against real providers: Anthropic passthrough 400/404 now return `{"type":"error",...}` with `request_id` and `anthropic-python` raises its typed `NotFoundError` with the native body; gateway auth / disabled-provider errors stay OpenAI-shaped; success bodies still byte-verbatim; malformed bodies on `/v1/chat/completions`, `/v1/messages` and `/v1/responses` return the new messages; six stop sequences now succeed on `openai/gpt-4.1-mini` and `groq/openai/gpt-oss-20b` and are still applied in full on Anthropic.
