### PR TITLE
fix(gateway): name provider instances, keep rate-limit subject spelling, hide upstream URLs

### DIFF
--- a/docs/features/rate-limits.mdx
+++ b/docs/features/rate-limits.mdx
@@ -162,7 +162,9 @@ on `/` applies to all traffic.
 Provider rules match the resolved provider instance by name. Model rules
 match the executed model: a provider-qualified subject (`openai/gpt-4o`)
 covers one provider's model, a bare subject (`gpt-4o`) covers that model on
-any provider. Matching is case-insensitive.
+any provider. Matching is case-insensitive, and the rule keeps the spelling
+you wrote it with — a rule on provider `openai-EU` is listed and reported as
+`openai-EU`, while still matching the route however it is cased.
 
 **A rule owns one shared counter for its whole subject.** A `100 rpm` rule on
 `/team` allows 100 requests per minute across everything under `/team`
@@ -255,6 +257,13 @@ with status `429` and a `Retry-After` header holding the seconds until a
 retry would actually be admitted under the sliding window (which can extend
 past the next window boundary). OpenAI SDKs back off automatically on this
 shape.
+
+The breach also carries the `x-ratelimit-*` headers for the limit that was
+hit: `limit`/`remaining`/`reset` for a request or token window. A
+**concurrency** breach sends `x-ratelimit-limit-requests` and
+`x-ratelimit-remaining-requests` (always `0`) but no
+`x-ratelimit-reset-requests`: an in-flight gauge has no window to reset — a
+slot frees when a request finishes, which is what `Retry-After` estimates.
 
 Successful responses on limited paths carry OpenAI-style headers from the
 most-constrained matching rule:

--- a/internal/admin/handler_ratelimits.go
+++ b/internal/admin/handler_ratelimits.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"cmp"
 	"errors"
 	"net/http"
 	"strconv"
@@ -67,9 +68,13 @@ func (h *Handler) UpsertRateLimit(c *echo.Context) error {
 		return handleError(c, err)
 	}
 	item, err := ratelimit.NormalizeRule(ratelimit.Rule{
-		Scope:         scope,
-		Subject:       subject,
-		PerChild:      req.PerChild,
+		Scope:   scope,
+		Subject: subject,
+		// The spelling the operator wrote: provider and model subjects are
+		// stored case-folded, and the folded form must not be what the rule
+		// is reported as.
+		SubjectDisplay: cmp.Or(strings.TrimSpace(req.Subject), strings.TrimSpace(req.UserPath)),
+		PerChild:       req.PerChild,
 		PeriodSeconds: periodSeconds,
 		MaxRequests:   req.MaxRequests,
 		MaxTokens:     req.MaxTokens,
@@ -255,7 +260,7 @@ func rateLimitStatusResponses(statuses []ratelimit.Status) []rateLimitStatusResp
 		rule := status.Rule
 		item := rateLimitStatusResponse{
 			Scope:             string(rule.Scope),
-			Subject:           rule.Subject,
+			Subject:           rule.DisplaySubject(),
 			PerChild:          rule.PerChild,
 			EffectiveSubject:  rule.EffectiveSubject,
 			PeriodSeconds:     rule.PeriodSeconds,

--- a/internal/admin/handler_ratelimits_test.go
+++ b/internal/admin/handler_ratelimits_test.go
@@ -307,8 +307,11 @@ func TestRateLimitEndpointsProviderAndModelScopes(t *testing.T) {
 		t.Fatalf("rate limits = %d, want 1", len(body.RateLimits))
 	}
 	item := body.RateLimits[0]
-	if item.Scope != "provider" || item.Subject != "openai" {
-		t.Fatalf("item = %+v, want provider openai (normalized lowercase)", item)
+	// Matching is case-insensitive, but the rule is reported with the
+	// spelling it was written with: the folded key names no configured
+	// provider.
+	if item.Scope != "provider" || item.Subject != "OpenAI" {
+		t.Fatalf("item = %+v, want provider OpenAI (written spelling)", item)
 	}
 	if item.UserPath != "" {
 		t.Fatalf("user_path = %q, want empty for provider rules", item.UserPath)
@@ -319,8 +322,8 @@ func TestRateLimitEndpointsProviderAndModelScopes(t *testing.T) {
 		t.Fatalf("Acquire() failed: %v", err)
 	}
 
-	// A model rule for the same period coexists; mixed-case subjects are
-	// stored lowercase and match lowercase live routes.
+	// A model rule for the same period coexists; mixed-case subjects match
+	// lowercase live routes and keep their written spelling.
 	modelCtx, modelRec := adminRateLimitRequest(
 		http.MethodPut,
 		`{"scope":"model","subject":"OpenAI/GPT-4o","limit_key":{"period":"minute"},"max_tokens":90000}`,
@@ -339,8 +342,8 @@ func TestRateLimitEndpointsProviderAndModelScopes(t *testing.T) {
 	for _, item := range modelBody.RateLimits {
 		if item.Scope == "model" {
 			foundModel = true
-			if item.Subject != "openai/gpt-4o" {
-				t.Fatalf("model subject = %q, want lowercase openai/gpt-4o", item.Subject)
+			if item.Subject != "OpenAI/GPT-4o" {
+				t.Fatalf("model subject = %q, want the written OpenAI/GPT-4o", item.Subject)
 			}
 		}
 	}

--- a/internal/gateway/empty_choices_test.go
+++ b/internal/gateway/empty_choices_test.go
@@ -50,9 +50,12 @@ func TestDispatchChatCompletionEmptyChoices(t *testing.T) {
 				}),
 			})
 			workflow := &core.Workflow{
-				Endpoint:   core.DescribeEndpoint("POST", "/v1/chat/completions"),
-				Resolution: &core.RequestModelResolution{ResolvedSelector: core.ModelSelector{Provider: "cloudflare", Model: "model1"}},
-				Policy:     &core.ResolvedWorkflowPolicy{Features: core.WorkflowFeatures{Failover: true}},
+				Endpoint: core.DescribeEndpoint("POST", "/v1/chat/completions"),
+				Resolution: &core.RequestModelResolution{
+					ResolvedSelector: core.ModelSelector{Provider: "cloudflare", Model: "model1"},
+					ProviderName:     "cloudflare-eu",
+				},
+				Policy: &core.ResolvedWorkflowPolicy{Features: core.WorkflowFeatures{Failover: true}},
 			}
 
 			response, _, err := orchestrator.DispatchChatCompletion(context.Background(), workflow, &core.ChatRequest{Model: "model1"})
@@ -71,6 +74,11 @@ func TestDispatchChatCompletionEmptyChoices(t *testing.T) {
 				}
 				if gatewayErr.Message != "provider returned no choices" {
 					t.Fatalf("error message = %q, want %q", gatewayErr.Message, "provider returned no choices")
+				}
+				// The configured instance, not the provider type the
+				// response body carries.
+				if gatewayErr.Provider != "cloudflare-eu" {
+					t.Fatalf("error provider = %q, want %q", gatewayErr.Provider, "cloudflare-eu")
 				}
 			}
 			if len(calls) != len(tt.wantCalls) {

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -137,7 +137,7 @@ func executeTranslatedWithFailover[Req any, Resp any](
 	req Req,
 	model, provider string,
 	cloneForSelector func(Req, core.ModelSelector) Req,
-	call func(context.Context, Req) (Resp, string, error),
+	call func(context.Context, Req, string) (Resp, string, error),
 ) (Resp, ExecutionMeta, error) {
 	return executeWithFailoverResponse(ctx, o, workflow, model, provider,
 		func() (Resp, string, string, error) {
@@ -150,7 +150,7 @@ func executeTranslatedWithFailover[Req any, Resp any](
 				recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindPrimary, ProviderTypeFromWorkflow(workflow), ProviderNameFromWorkflow(workflow), currentSelectorForWorkflow(workflow, model, provider), started, saturated))
 				return zero, "", "", saturated
 			}
-			resp, responseProvider, err := call(ctx, req)
+			resp, responseProvider, err := call(ctx, req, ProviderNameFromWorkflow(workflow))
 			attemptProviderType := ResponseProviderType(ProviderTypeFromWorkflow(workflow), responseProvider)
 			recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindPrimary, attemptProviderType, ProviderNameFromWorkflow(workflow), currentSelectorForWorkflow(workflow, model, provider), started, err))
 			if err != nil {
@@ -159,7 +159,7 @@ func executeTranslatedWithFailover[Req any, Resp any](
 			return resp, ResponseProviderType(ProviderTypeFromWorkflow(workflow), responseProvider), ProviderNameFromWorkflow(workflow), nil
 		},
 		func(selector core.ModelSelector, providerType, providerName string) (Resp, string, error) {
-			resp, responseProvider, err := call(ctx, cloneForSelector(req, selector))
+			resp, responseProvider, err := call(ctx, cloneForSelector(req, selector), providerName)
 			if err != nil {
 				var zero Resp
 				return zero, "", err

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -231,7 +231,7 @@ func TestExecuteTranslatedSkipsSaturatedPrimaryAndFailsOver(t *testing.T) {
 	resp, meta, err := executeTranslatedWithFailover(
 		ctx, o, workflow, "req", "openai/gpt-4o", "openai",
 		func(req string, selector core.ModelSelector) string { return selector.QualifiedModel() },
-		func(_ context.Context, req string) (string, string, error) {
+		func(_ context.Context, req string, _ string) (string, string, error) {
 			calls = append(calls, req)
 			if req == "req" {
 				t.Fatal("saturated primary route reached the provider")
@@ -259,7 +259,7 @@ func TestExecuteTranslatedSaturatedPrimarySurfaces429WhenNoTargetRemains(t *test
 	_, meta, err := executeTranslatedWithFailover(
 		ctx, o, workflow, "req", "openai/gpt-4o", "openai",
 		func(req string, selector core.ModelSelector) string { return selector.QualifiedModel() },
-		func(_ context.Context, _ string) (string, string, error) {
+		func(_ context.Context, _ string, _ string) (string, string, error) {
 			t.Fatal("no provider call expected: primary saturated, failover gated")
 			return "", "", nil
 		},
@@ -285,7 +285,7 @@ func TestStreamTranslatedSkipsSaturatedPrimaryAndFailsOver(t *testing.T) {
 		o, ctx, workflow, "req", "openai/gpt-4o", "openai",
 		"openai", "openai", "gpt-4o",
 		func(req string, selector core.ModelSelector) string { return selector.QualifiedModel() },
-		func(_ context.Context, req string) (io.ReadCloser, error) {
+		func(_ context.Context, req string, _ string) (io.ReadCloser, error) {
 			calls = append(calls, req)
 			if req == "req" {
 				t.Fatal("saturated primary route reached the provider")

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -210,18 +210,18 @@ func (o *InferenceOrchestrator) executeResponses(
 // in front of call. The attempt's provider type comes from the request's own
 // selector, which the primary carries after resolution and a failover clone
 // carries from its target, falling back to the workflow's provider type.
-func patchedResponsesCall[T any](o *InferenceOrchestrator, workflow *core.Workflow, call func(context.Context, *core.ResponsesRequest) (T, error)) func(context.Context, *core.ResponsesRequest) (T, error) {
+func patchedResponsesCall[T any](o *InferenceOrchestrator, workflow *core.Workflow, call func(context.Context, *core.ResponsesRequest, string) (T, error)) func(context.Context, *core.ResponsesRequest, string) (T, error) {
 	if o.responsesAttemptPatcher == nil {
 		return call
 	}
-	return func(ctx context.Context, req *core.ResponsesRequest) (T, error) {
+	return func(ctx context.Context, req *core.ResponsesRequest, providerName string) (T, error) {
 		providerType := o.ProviderTypeForSelector(core.ModelSelector{Model: req.Model, Provider: req.Provider}, ProviderTypeFromWorkflow(workflow))
 		patched, err := o.responsesAttemptPatcher.PatchResponsesAttempt(ctx, req, providerType)
 		if err != nil {
 			var zero T
 			return zero, err
 		}
-		return call(ctx, patched)
+		return call(ctx, patched, providerName)
 	}
 }
 
@@ -342,12 +342,12 @@ func executeTranslatedProviderRequest[Req any, Resp any](
 	req Req,
 	model, provider string,
 	cloneForSelector func(Req, core.ModelSelector) Req,
-	call func(context.Context, Req) (Resp, error),
+	call func(context.Context, Req, string) (Resp, error),
 	responseProvider func(Resp) string,
 ) (Resp, ExecutionMeta, error) {
 	return executeTranslatedWithFailover(ctx, o, workflow, req, model, provider, cloneForSelector,
-		func(ctx context.Context, req Req) (Resp, string, error) {
-			resp, err := call(ctx, req)
+		func(ctx context.Context, req Req, providerName string) (Resp, string, error) {
+			resp, err := call(ctx, req, providerName)
 			if err != nil {
 				var zero Resp
 				return zero, "", err
@@ -365,7 +365,7 @@ func streamTranslatedProviderRequest[Req any](
 	model, provider string,
 	providerType, providerName, usageModel string,
 	cloneForSelector func(Req, core.ModelSelector) Req,
-	call func(context.Context, Req) (io.ReadCloser, error),
+	call func(context.Context, Req, string) (io.ReadCloser, error),
 ) (io.ReadCloser, ExecutionMeta, error) {
 	started := time.Now()
 	var stream io.ReadCloser
@@ -373,25 +373,25 @@ func streamTranslatedProviderRequest[Req any](
 	// the provider call and enters the failover sweep with its stored 429.
 	err := core.PrimaryRouteSaturated(ctx)
 	if err == nil {
-		stream, err = call(ctx, req)
+		stream, err = call(ctx, req, providerName)
 		if err == nil && stream != nil {
 			recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindPrimary, providerType, providerName, currentSelectorForWorkflow(workflow, model, provider), started, nil))
 			return stream, ExecutionMeta{ProviderType: providerType, ProviderName: providerName, Model: usageModel}, nil
 		}
 		if err == nil {
-			err = emptyProviderStreamError(providerType)
+			err = emptyProviderStreamError(providerName)
 		}
 	}
 	recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindPrimary, providerType, providerName, currentSelectorForWorkflow(workflow, model, provider), started, err))
 
 	return tryFailoverStream(ctx, o, workflow, model, provider, err,
 		func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error) {
-			stream, err := call(ctx, cloneForSelector(req, selector))
+			stream, err := call(ctx, cloneForSelector(req, selector), providerName)
 			if err != nil {
 				return nil, "", "", err
 			}
 			if stream == nil {
-				return nil, "", "", emptyProviderStreamError(providerType)
+				return nil, "", "", emptyProviderStreamError(providerName)
 			}
 			return stream, providerType, selector.Model, nil
 		},
@@ -408,45 +408,49 @@ func (o *InferenceOrchestrator) validateProviderAndRequest(requestPresent bool, 
 	return nil
 }
 
-func (o *InferenceOrchestrator) chatCompletionProviderCall(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+// The provider name of the attempt — not the provider type the response body
+// carries — names these gateway-raised errors, so an operator running two
+// instances of one type can tell which instance answered (see
+// ResolvedProviderName).
+func (o *InferenceOrchestrator) chatCompletionProviderCall(ctx context.Context, req *core.ChatRequest, providerName string) (*core.ChatResponse, error) {
 	resp, err := o.provider.ChatCompletion(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	if resp == nil {
-		return nil, emptyProviderResponseError("")
+		return nil, emptyProviderResponseError(providerName)
 	}
 	if len(resp.Choices) == 0 {
-		return nil, core.NewNoChoicesProviderError(resp.Provider)
+		return nil, core.NewNoChoicesProviderError(providerName)
 	}
 	return resp, nil
 }
 
-func (o *InferenceOrchestrator) responsesProviderCall(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+func (o *InferenceOrchestrator) responsesProviderCall(ctx context.Context, req *core.ResponsesRequest, providerName string) (*core.ResponsesResponse, error) {
 	resp, err := o.provider.Responses(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	if resp == nil {
-		return nil, emptyProviderResponseError("")
+		return nil, emptyProviderResponseError(providerName)
 	}
 	return resp, nil
 }
 
-func (o *InferenceOrchestrator) streamChatCompletionProviderCall(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+func (o *InferenceOrchestrator) streamChatCompletionProviderCall(ctx context.Context, req *core.ChatRequest, _ string) (io.ReadCloser, error) {
 	return o.provider.StreamChatCompletion(ctx, req)
 }
 
-func (o *InferenceOrchestrator) streamResponsesProviderCall(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+func (o *InferenceOrchestrator) streamResponsesProviderCall(ctx context.Context, req *core.ResponsesRequest, _ string) (io.ReadCloser, error) {
 	return o.provider.StreamResponses(ctx, req)
 }
 
-func emptyProviderResponseError(providerType string) *core.GatewayError {
-	return core.NewEmptyProviderResponseError(providerType)
+func emptyProviderResponseError(provider string) *core.GatewayError {
+	return core.NewEmptyProviderResponseError(provider)
 }
 
-func emptyProviderStreamError(providerType string) *core.GatewayError {
-	return core.NewProviderError(providerType, http.StatusBadGateway, "provider returned empty stream", nil)
+func emptyProviderStreamError(provider string) *core.GatewayError {
+	return core.NewProviderError(provider, http.StatusBadGateway, "provider returned empty stream", nil)
 }
 
 func chatResponseModel(resp *core.ChatResponse) string {
@@ -504,7 +508,7 @@ func (o *InferenceOrchestrator) executeEmbeddings(
 	resp, err := o.provider.Embeddings(ctx, req)
 	if err == nil {
 		if resp == nil {
-			return nil, "", "", emptyProviderResponseError(providerType)
+			return nil, "", "", emptyProviderResponseError(providerName)
 		}
 		return resp, ResponseProviderType(providerType, resp.Provider), providerName, nil
 	}

--- a/internal/llmclient/client_request.go
+++ b/internal/llmclient/client_request.go
@@ -3,12 +3,15 @@ package llmclient
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/goccy/go-json"
 
@@ -76,9 +79,71 @@ func (c *Client) doHTTPRequest(ctx context.Context, req Request) (*http.Response
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), "failed to send request: "+err.Error(), err)
+		logTransportError("provider request failed", c.config.ProviderName, req.Endpoint, err)
+		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), transportErrorMessage(err), err)
 	}
 	return resp, nil
+}
+
+// logTransportError records the full transport error — including the upstream
+// URL the client never sees — for operators.
+func logTransportError(message, providerName, endpoint string, err error) {
+	slog.Warn(message,
+		"provider", providerName,
+		"endpoint", endpoint,
+		"error", err,
+	)
+}
+
+// transportErrorMessage summarizes a transport failure for the client. The
+// raw error embeds the upstream URL (a private hostname, an Azure deployment
+// path, or a token an operator put in a custom base_url), so it is logged
+// server-side and never returned. The summary still distinguishes the failure
+// modes operators triage by, and providerErrorStatusCode keeps the status
+// mapping (timeout 504, everything else 502).
+func transportErrorMessage(err error) string {
+	switch {
+	case isTimeoutError(err):
+		return "provider request timed out"
+	case errors.Is(err, context.Canceled):
+		return "provider request canceled"
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return "provider refused the connection"
+	case isTLSError(err):
+		return "TLS handshake with provider failed"
+	case isDNSError(err):
+		return "provider host could not be resolved"
+	default:
+		return "failed to send request to provider"
+	}
+}
+
+// readErrorMessage summarizes a failure while reading the upstream response
+// body. Like transportErrorMessage it withholds the connection details the
+// raw error carries (local and upstream addresses).
+func readErrorMessage(err error) string {
+	if isTimeoutError(err) {
+		return "timed out reading provider response"
+	}
+	return "failed to read provider response"
+}
+
+func isTLSError(err error) bool {
+	if _, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[tls.RecordHeaderError](err); ok {
+		return true
+	}
+	// Handshake failures the standard library reports as plain messages
+	// ("tls: first record does not look like a TLS handshake", "x509: ...").
+	message := err.Error()
+	return strings.Contains(message, "tls:") || strings.Contains(message, "x509:")
+}
+
+func isDNSError(err error) bool {
+	_, ok := errors.AsType[*net.DNSError](err)
+	return ok
 }
 
 // closeRawBodyReader releases a caller-supplied streaming body when the
@@ -113,7 +178,8 @@ func (c *Client) doRequest(ctx context.Context, req Request) (*Response, error) 
 	}
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), "failed to read response: "+err.Error(), err)
+		logTransportError("reading provider response failed", c.config.ProviderName, req.Endpoint, err)
+		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), readErrorMessage(err), err)
 	}
 
 	return &Response{

--- a/internal/llmclient/client_request.go
+++ b/internal/llmclient/client_request.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"syscall"
 
@@ -85,14 +86,46 @@ func (c *Client) doHTTPRequest(ctx context.Context, req Request) (*http.Response
 	return resp, nil
 }
 
-// logTransportError records the full transport error — including the upstream
-// URL the client never sees — for operators.
+// logTransportError records the transport error for operators, including the
+// upstream URL the client never sees — minus any credential an operator
+// embedded in a custom base_url.
 func logTransportError(message, providerName, endpoint string, err error) {
 	slog.Warn(message,
 		"provider", providerName,
 		"endpoint", endpoint,
-		"error", err,
+		"error", sanitizedTransportError(err),
 	)
+}
+
+// sanitizedTransportError renders a transport error with the upstream URL
+// stripped of userinfo, query and fragment: a base_url may carry a token in
+// any of them, and secrets must not reach the logs either.
+func sanitizedTransportError(err error) string {
+	if err == nil {
+		return ""
+	}
+	urlErr, ok := errors.AsType[*url.Error](err)
+	if !ok {
+		return err.Error()
+	}
+	inner := "unknown error"
+	if urlErr.Err != nil {
+		inner = urlErr.Err.Error()
+	}
+	return fmt.Sprintf("%s %q: %s", urlErr.Op, redactedURL(urlErr.URL), inner)
+}
+
+func redactedURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "[unparsable url]"
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	return parsed.String()
 }
 
 // transportErrorMessage summarizes a transport failure for the client. The

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -1759,7 +1759,7 @@ func TestClient_Do_HTTPTimeoutReturnsGatewayTimeout(t *testing.T) {
 	if gatewayErr.StatusCode != http.StatusGatewayTimeout {
 		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusGatewayTimeout)
 	}
-	if !strings.Contains(gatewayErr.Message, "failed to send request") {
+	if gatewayErr.Message != "provider request timed out" {
 		t.Fatalf("Message = %q, want send-request timeout context", gatewayErr.Message)
 	}
 }
@@ -1909,7 +1909,7 @@ func TestClient_Do_BodyReadTimeoutReturnsGatewayTimeout(t *testing.T) {
 	if gatewayErr.StatusCode != http.StatusGatewayTimeout {
 		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusGatewayTimeout)
 	}
-	if !strings.Contains(gatewayErr.Message, "failed to read response") {
+	if gatewayErr.Message != "timed out reading provider response" {
 		t.Fatalf("Message = %q, want read-response timeout context", gatewayErr.Message)
 	}
 }

--- a/internal/llmclient/client_transport_error_test.go
+++ b/internal/llmclient/client_transport_error_test.go
@@ -1,0 +1,138 @@
+package llmclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// A transport error must never hand the client the upstream URL: it discloses
+// internal topology and would leak a token embedded in a custom base_url.
+func TestTransportErrorMessage(t *testing.T) {
+	const upstream = "https://secret-host.internal:8443/v1/chat/completions?key=s3cret"
+	wrap := func(err error) error {
+		return &url.Error{Op: "Post", URL: upstream, Err: err}
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "timeout",
+			err:  wrap(errors.New("net/http: timeout awaiting response headers")),
+			want: "provider request timed out",
+		},
+		{
+			name: "deadline exceeded",
+			err:  wrap(context.DeadlineExceeded),
+			want: "provider request timed out",
+		},
+		{
+			name: "canceled",
+			err:  wrap(context.Canceled),
+			want: "provider request canceled",
+		},
+		{
+			name: "connection refused",
+			err:  wrap(&net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}),
+			want: "provider refused the connection",
+		},
+		{
+			name: "tls handshake",
+			err:  wrap(tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}),
+			want: "TLS handshake with provider failed",
+		},
+		{
+			name: "certificate verification",
+			err:  wrap(&tls.CertificateVerificationError{Err: errors.New("certificate signed by unknown authority")}),
+			want: "TLS handshake with provider failed",
+		},
+		{
+			name: "dns failure",
+			err:  wrap(&net.DNSError{Err: "no such host", Name: "secret-host.internal", IsNotFound: true}),
+			want: "provider host could not be resolved",
+		},
+		{
+			name: "unclassified",
+			err:  wrap(errors.New("connection reset by peer")),
+			want: "failed to send request to provider",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := transportErrorMessage(tt.err)
+			if got != tt.want {
+				t.Fatalf("transportErrorMessage() = %q, want %q", got, tt.want)
+			}
+			if strings.Contains(got, "secret-host.internal") || strings.Contains(got, "s3cret") {
+				t.Fatalf("transportErrorMessage() = %q, must not disclose the upstream URL", got)
+			}
+		})
+	}
+}
+
+func TestReadErrorMessage(t *testing.T) {
+	if got := readErrorMessage(context.DeadlineExceeded); got != "timed out reading provider response" {
+		t.Fatalf("readErrorMessage(timeout) = %q", got)
+	}
+	got := readErrorMessage(&net.OpError{Op: "read", Net: "tcp", Source: mustAddr(t, "127.0.0.1:51423"), Err: errors.New("connection reset by peer")})
+	if got != "failed to read provider response" {
+		t.Fatalf("readErrorMessage() = %q", got)
+	}
+	if strings.Contains(got, "127.0.0.1") {
+		t.Fatalf("readErrorMessage() = %q, must not disclose connection details", got)
+	}
+}
+
+// End to end: a refused connection keeps its 502 mapping and names the
+// provider, without echoing the base URL back to the caller.
+func TestClientTransportErrorHidesBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := server.URL
+	server.Close() // nothing listens on the port any more
+
+	cfg := DefaultConfig("mockB", baseURL)
+	cfg.Retry.MaxRetries = 0
+	client := NewWithHTTPClient(&http.Client{Timeout: time.Second}, cfg, nil)
+
+	err := client.Do(context.Background(), Request{Method: http.MethodPost, Endpoint: "/chat/completions"}, nil)
+
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("error = %v (%T), want *core.GatewayError", err, err)
+	}
+	if gatewayErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusBadGateway)
+	}
+	if gatewayErr.Provider != "mockB" {
+		t.Fatalf("Provider = %q, want %q", gatewayErr.Provider, "mockB")
+	}
+	if strings.Contains(gatewayErr.Message, baseURL) || strings.Contains(gatewayErr.Message, "127.0.0.1") {
+		t.Fatalf("Message = %q, must not disclose the upstream URL", gatewayErr.Message)
+	}
+	// The full error stays available server-side for logs and diagnostics.
+	if gatewayErr.Err == nil || !strings.Contains(gatewayErr.Err.Error(), baseURL) {
+		t.Fatalf("wrapped error = %v, want the full transport error", gatewayErr.Err)
+	}
+}
+
+func mustAddr(t *testing.T, addr string) net.Addr {
+	t.Helper()
+	parsed, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		t.Fatalf("ResolveTCPAddr(%q) = %v", addr, err)
+	}
+	return parsed
+}

--- a/internal/llmclient/client_transport_error_test.go
+++ b/internal/llmclient/client_transport_error_test.go
@@ -83,6 +83,46 @@ func TestTransportErrorMessage(t *testing.T) {
 	}
 }
 
+// The server-side log keeps the upstream URL for diagnosis, but not a
+// credential an operator embedded in a custom base_url.
+func TestSanitizedTransportError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		want       string
+		wantAbsent string
+	}{
+		{
+			name:       "query credential is dropped",
+			err:        &url.Error{Op: "Post", URL: "https://host.internal:8443/v1/chat/completions?key=s3cret", Err: errors.New("connection refused")},
+			want:       `Post "https://host.internal:8443/v1/chat/completions": connection refused`,
+			wantAbsent: "s3cret",
+		},
+		{
+			name:       "userinfo is dropped",
+			err:        &url.Error{Op: "Post", URL: "https://user:p4ssw0rd@host.internal/v1/chat/completions", Err: errors.New("connection refused")},
+			want:       `Post "https://host.internal/v1/chat/completions": connection refused`,
+			wantAbsent: "p4ssw0rd",
+		},
+		{
+			name: "non-URL errors pass through",
+			err:  errors.New("connection reset by peer"),
+			want: "connection reset by peer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizedTransportError(tt.err)
+			if got != tt.want {
+				t.Fatalf("sanitizedTransportError() = %q, want %q", got, tt.want)
+			}
+			if tt.wantAbsent != "" && strings.Contains(got, tt.wantAbsent) {
+				t.Fatalf("sanitizedTransportError() = %q, must not contain %q", got, tt.wantAbsent)
+			}
+		})
+	}
+}
+
 func TestReadErrorMessage(t *testing.T) {
 	if got := readErrorMessage(context.DeadlineExceeded); got != "timed out reading provider response" {
 		t.Fatalf("readErrorMessage(timeout) = %q", got)

--- a/internal/ratelimit/factory.go
+++ b/internal/ratelimit/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -104,9 +105,12 @@ func seedConfiguredRules(ctx context.Context, service *Service, cfg config.RateL
 				seconds = parsed
 			}
 			rules = append(rules, Rule{
-				Scope:         scope,
-				Subject:       normalized,
-				PerChild:      perChild || limit.PerChild,
+				Scope:   scope,
+				Subject: normalized,
+				// Keep the configured spelling for display; provider and
+				// model subjects are stored case-folded to match.
+				SubjectDisplay: strings.TrimSpace(subject),
+				PerChild:       perChild || limit.PerChild,
 				PeriodSeconds: seconds,
 				MaxRequests:   limit.MaxRequests,
 				MaxTokens:     limit.MaxTokens,

--- a/internal/ratelimit/factory.go
+++ b/internal/ratelimit/factory.go
@@ -111,10 +111,10 @@ func seedConfiguredRules(ctx context.Context, service *Service, cfg config.RateL
 				// model subjects are stored case-folded to match.
 				SubjectDisplay: strings.TrimSpace(subject),
 				PerChild:       perChild || limit.PerChild,
-				PeriodSeconds: seconds,
-				MaxRequests:   limit.MaxRequests,
-				MaxTokens:     limit.MaxTokens,
-				Source:        SourceConfig,
+				PeriodSeconds:  seconds,
+				MaxRequests:    limit.MaxRequests,
+				MaxTokens:      limit.MaxTokens,
+				Source:         SourceConfig,
 			})
 		}
 		return nil

--- a/internal/ratelimit/service_test.go
+++ b/internal/ratelimit/service_test.go
@@ -191,6 +191,47 @@ func TestSeedConfiguredRulesCarriesPerChild(t *testing.T) {
 	}
 }
 
+// Provider and model subjects are matched case-insensitively, so configuration
+// seeds the folded subject as the key while keeping the configured spelling for
+// listings and breach messages.
+func TestSeedConfiguredRulesKeepsConfiguredSpelling(t *testing.T) {
+	store := &memStore{}
+	service, err := NewService(context.Background(), store)
+	if err != nil {
+		t.Fatalf("NewService() failed: %v", err)
+	}
+	limits := []config.RateLimitRuleConfig{{Period: "minute", MaxRequests: new(int64(10))}}
+	err = seedConfiguredRules(context.Background(), service, config.RateLimitsConfig{
+		Providers: []config.RateLimitProviderConfig{{Name: "mockA", Limits: limits}},
+		Models:    []config.RateLimitModelConfig{{Model: "GPT-4.1-Mini", Limits: limits}},
+	})
+	if err != nil {
+		t.Fatalf("seedConfiguredRules() failed: %v", err)
+	}
+
+	bySubject := make(map[string]Rule)
+	for _, rule := range service.Rules() {
+		bySubject[rule.Subject] = rule
+	}
+	if len(bySubject) != 2 {
+		t.Fatalf("seeded rules = %+v, want 2", service.Rules())
+	}
+	provider, ok := bySubject["mocka"]
+	if !ok {
+		t.Fatalf("seeded rules = %+v, want the folded provider subject", service.Rules())
+	}
+	if got := provider.DisplaySubject(); got != "mockA" {
+		t.Fatalf("provider DisplaySubject() = %q, want %q", got, "mockA")
+	}
+	model, ok := bySubject["gpt-4.1-mini"]
+	if !ok {
+		t.Fatalf("seeded rules = %+v, want the folded model subject", service.Rules())
+	}
+	if got := model.DisplaySubject(); got != "GPT-4.1-Mini" {
+		t.Fatalf("model DisplaySubject() = %q, want %q", got, "GPT-4.1-Mini")
+	}
+}
+
 // windowBase is aligned to every supported period, keeping sliding-window
 // math in tests exact.
 var windowBase = time.Unix(1_000_000_200, 0).UTC() // 1_000_000_200 % 600 == 0

--- a/internal/ratelimit/store_mongodb.go
+++ b/internal/ratelimit/store_mongodb.go
@@ -126,6 +126,7 @@ func (s *MongoDBStore) upsertNormalizedRules(ctx context.Context, rules []Rule) 
 		update := bson.D{{Key: "$set", Value: bson.D{
 			{Key: "scope", Value: rule.Scope},
 			{Key: "subject", Value: rule.Subject},
+			{Key: "subject_display", Value: rule.SubjectDisplay},
 			{Key: "per_child", Value: rule.PerChild},
 			{Key: "period_seconds", Value: rule.PeriodSeconds},
 			{Key: "max_requests", Value: rule.MaxRequests},

--- a/internal/ratelimit/store_mongodb_test.go
+++ b/internal/ratelimit/store_mongodb_test.go
@@ -179,6 +179,60 @@ func TestClassifyBulkWriteError(t *testing.T) {
 	}
 }
 
+// TestMongoDBStoreSubjectDisplayPrecedence is the MongoDB half of
+// TestSQLStoreSubjectDisplayPrecedence: the folded subject stays the key, and a
+// config re-seed may not re-spell a subject an operator edited by hand.
+func TestMongoDBStoreSubjectDisplayPrecedence(t *testing.T) {
+	tests := []struct {
+		name        string
+		storedSpell string
+		storedSrc   string
+		nextSpell   string
+		nextSrc     string
+		want        string
+	}{
+		{name: "config over config", storedSpell: "mockA", storedSrc: SourceConfig, nextSpell: "MOCKA", nextSrc: SourceConfig, want: "MOCKA"},
+		{name: "config over manual", storedSpell: "mockA", storedSrc: SourceManual, nextSpell: "MOCKA", nextSrc: SourceConfig, want: "mockA"},
+		{name: "manual over config", storedSpell: "mockA", storedSrc: SourceConfig, nextSpell: "MOCKA", nextSrc: SourceManual, want: "MOCKA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mongotest.Run(t, func(t *testing.T, db *mongo.Database) {
+				ctx := context.Background()
+				store, err := NewMongoDBStore(ctx, db)
+				if err != nil {
+					t.Fatalf("NewMongoDBStore() failed: %v", err)
+				}
+
+				if err := store.UpsertRules(ctx, []Rule{
+					{Scope: ScopeProvider, Subject: tt.storedSpell, PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1)), Source: tt.storedSrc},
+				}); err != nil {
+					t.Fatalf("UpsertRules() failed: %v", err)
+				}
+				if err := store.UpsertRules(ctx, []Rule{
+					{Scope: ScopeProvider, Subject: tt.nextSpell, PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(2)), Source: tt.nextSrc},
+				}); err != nil {
+					t.Fatalf("second UpsertRules() failed: %v", err)
+				}
+
+				rules, err := store.ListRules(ctx)
+				if err != nil {
+					t.Fatalf("ListRules() failed: %v", err)
+				}
+				if len(rules) != 1 {
+					t.Fatalf("rules = %d, want 1: %+v", len(rules), rules)
+				}
+				if rules[0].Subject != "mocka" {
+					t.Fatalf("Subject = %q, want the folded match key", rules[0].Subject)
+				}
+				if got := rules[0].DisplaySubject(); got != tt.want {
+					t.Fatalf("DisplaySubject() = %q, want %q", got, tt.want)
+				}
+			})
+		})
+	}
+}
+
 // A MongoDB database written before rule scopes existed carries a unique index
 // on (user_path, period_seconds). Unsetting user_path collapses every migrated
 // document of the same period onto one index key, so the legacy index has to go

--- a/internal/ratelimit/store_sql.go
+++ b/internal/ratelimit/store_sql.go
@@ -17,6 +17,7 @@ const sqlRateLimitsSchema = `
 	CREATE TABLE IF NOT EXISTS rate_limits (
 		scope TEXT NOT NULL DEFAULT 'user_path',
 		subject TEXT NOT NULL,
+		subject_display TEXT NOT NULL DEFAULT '',
 		per_child ` + sqlx.TypeBool + ` NOT NULL DEFAULT FALSE,
 		period_seconds ` + sqlx.TypeInt64 + ` NOT NULL,
 		max_requests ` + sqlx.TypeInt64 + `,
@@ -52,9 +53,10 @@ type SQLStore struct {
 // a column is only overwritten when the incoming or stored row is manual, or
 // when both are config-sourced.
 const upsertRuleSQL = `
-	INSERT INTO rate_limits (scope, subject, per_child, period_seconds, max_requests, max_tokens, source, created_at, updated_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	INSERT INTO rate_limits (scope, subject, subject_display, per_child, period_seconds, max_requests, max_tokens, source, created_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(scope, subject, period_seconds) DO UPDATE SET
+		subject_display = CASE WHEN excluded.source = ? OR rate_limits.source = ? THEN excluded.subject_display ELSE rate_limits.subject_display END,
 		per_child = CASE WHEN excluded.source = ? OR rate_limits.source = ? THEN excluded.per_child ELSE rate_limits.per_child END,
 		max_requests = CASE WHEN excluded.source = ? OR rate_limits.source = ? THEN excluded.max_requests ELSE rate_limits.max_requests END,
 		max_tokens = CASE WHEN excluded.source = ? OR rate_limits.source = ? THEN excluded.max_tokens ELSE rate_limits.max_tokens END,
@@ -76,6 +78,7 @@ func NewSQLStore(ctx context.Context, db sqlx.DB) (*SQLStore, error) {
 	}
 	if err := sqlx.AddColumns(ctx, db,
 		`ALTER TABLE rate_limits ADD COLUMN per_child `+sqlx.TypeBool+` NOT NULL DEFAULT FALSE`,
+		`ALTER TABLE rate_limits ADD COLUMN subject_display TEXT NOT NULL DEFAULT ''`,
 	); err != nil {
 		return nil, fmt.Errorf("failed to migrate rate_limits table: %w", err)
 	}
@@ -90,7 +93,7 @@ func NewSQLStore(ctx context.Context, db sqlx.DB) (*SQLStore, error) {
 
 func (s *SQLStore) ListRules(ctx context.Context) ([]Rule, error) {
 	rows, err := s.db.Query(ctx, `
-		SELECT scope, subject, per_child, period_seconds, max_requests, max_tokens, source, created_at, updated_at
+		SELECT scope, subject, subject_display, per_child, period_seconds, max_requests, max_tokens, source, created_at, updated_at
 		FROM rate_limits
 		ORDER BY scope ASC, subject ASC, period_seconds ASC
 	`)
@@ -278,6 +281,7 @@ func upsertRules(ctx context.Context, q sqlx.Querier, rules []Rule) error {
 		_, err := q.Exec(ctx, upsertRuleSQL,
 			rule.Scope,
 			rule.Subject,
+			rule.SubjectDisplay,
 			rule.PerChild,
 			rule.PeriodSeconds,
 			nullableInt64(rule.MaxRequests),
@@ -285,6 +289,7 @@ func upsertRules(ctx context.Context, q sqlx.Querier, rules []Rule) error {
 			rule.Source,
 			rule.CreatedAt.Unix(),
 			rule.UpdatedAt.Unix(),
+			SourceManual, SourceConfig,
 			SourceManual, SourceConfig,
 			SourceManual, SourceConfig,
 			SourceManual, SourceConfig,
@@ -306,6 +311,7 @@ func scanSQLRule(scanner sqlx.Row) (Rule, error) {
 	if err := scanner.Scan(
 		&rule.Scope,
 		&rule.Subject,
+		&rule.SubjectDisplay,
 		&rule.PerChild,
 		&rule.PeriodSeconds,
 		&maxRequests,

--- a/internal/ratelimit/store_sql_test.go
+++ b/internal/ratelimit/store_sql_test.go
@@ -70,6 +70,34 @@ func TestSQLStoreRoundTripsNullableLimits(t *testing.T) {
 	})
 }
 
+// The folded subject stays the key; the written spelling survives the round
+// trip so breaches and listings can name a provider that exists.
+func TestSQLStoreRoundTripsSubjectDisplay(t *testing.T) {
+	runSQLStoreTest(t, func(t *testing.T, store *SQLStore) {
+		ctx := context.Background()
+
+		if err := store.UpsertRules(ctx, []Rule{
+			{Scope: ScopeProvider, Subject: "mockA", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1)), Source: SourceManual},
+		}); err != nil {
+			t.Fatalf("UpsertRules() failed: %v", err)
+		}
+
+		rules, err := store.ListRules(ctx)
+		if err != nil {
+			t.Fatalf("ListRules() failed: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("rules = %d, want 1", len(rules))
+		}
+		if rules[0].Subject != "mocka" {
+			t.Fatalf("Subject = %q, want the folded match key", rules[0].Subject)
+		}
+		if got := rules[0].DisplaySubject(); got != "mockA" {
+			t.Fatalf("DisplaySubject() = %q, want %q", got, "mockA")
+		}
+	})
+}
+
 func TestSQLStoreDeleteRule(t *testing.T) {
 	runSQLStoreTest(t, func(t *testing.T, store *SQLStore) {
 		ctx := context.Background()

--- a/internal/ratelimit/store_sql_test.go
+++ b/internal/ratelimit/store_sql_test.go
@@ -98,6 +98,55 @@ func TestSQLStoreRoundTripsSubjectDisplay(t *testing.T) {
 	})
 }
 
+// subject_display follows the same source precedence as the limits: a config
+// re-seed may not re-spell a subject an operator edited by hand.
+func TestSQLStoreSubjectDisplayPrecedence(t *testing.T) {
+	tests := []struct {
+		name        string
+		storedSpell string
+		storedSrc   string
+		nextSpell   string
+		nextSrc     string
+		want        string
+	}{
+		{name: "config over config", storedSpell: "mockA", storedSrc: SourceConfig, nextSpell: "MOCKA", nextSrc: SourceConfig, want: "MOCKA"},
+		{name: "config over manual", storedSpell: "mockA", storedSrc: SourceManual, nextSpell: "MOCKA", nextSrc: SourceConfig, want: "mockA"},
+		{name: "manual over config", storedSpell: "mockA", storedSrc: SourceConfig, nextSpell: "MOCKA", nextSrc: SourceManual, want: "MOCKA"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runSQLStoreTest(t, func(t *testing.T, store *SQLStore) {
+				ctx := context.Background()
+
+				if err := store.UpsertRules(ctx, []Rule{
+					{Scope: ScopeProvider, Subject: tt.storedSpell, PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1)), Source: tt.storedSrc},
+				}); err != nil {
+					t.Fatalf("UpsertRules() failed: %v", err)
+				}
+				if err := store.UpsertRules(ctx, []Rule{
+					{Scope: ScopeProvider, Subject: tt.nextSpell, PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(2)), Source: tt.nextSrc},
+				}); err != nil {
+					t.Fatalf("second UpsertRules() failed: %v", err)
+				}
+
+				rules, err := store.ListRules(ctx)
+				if err != nil {
+					t.Fatalf("ListRules() failed: %v", err)
+				}
+				if len(rules) != 1 {
+					t.Fatalf("rules = %d, want 1: %+v", len(rules), rules)
+				}
+				if rules[0].Subject != "mocka" {
+					t.Fatalf("Subject = %q, want the folded match key", rules[0].Subject)
+				}
+				if got := rules[0].DisplaySubject(); got != tt.want {
+					t.Fatalf("DisplaySubject() = %q, want %q", got, tt.want)
+				}
+			})
+		})
+	}
+}
+
 func TestSQLStoreDeleteRule(t *testing.T) {
 	runSQLStoreTest(t, func(t *testing.T, store *SQLStore) {
 		ctx := context.Background()

--- a/internal/ratelimit/types.go
+++ b/internal/ratelimit/types.go
@@ -48,9 +48,14 @@ const (
 // Rule stores the limits for one scope, subject, and period.
 // A period of PeriodConcurrent caps in-flight requests via MaxRequests.
 type Rule struct {
-	Scope    RuleScope `json:"scope" bson:"scope"`
-	Subject  string    `json:"subject" bson:"subject"`
-	PerChild bool      `json:"per_child" bson:"per_child"`
+	Scope   RuleScope `json:"scope" bson:"scope"`
+	Subject string    `json:"subject" bson:"subject"`
+	// SubjectDisplay keeps the spelling the rule was written with for
+	// provider and model scopes, whose Subject is case-folded to stay the
+	// match key. It is empty when the two agree, and rules stored before it
+	// existed simply fall back to Subject.
+	SubjectDisplay string `json:"subject_display,omitempty" bson:"subject_display,omitempty"`
+	PerChild       bool   `json:"per_child" bson:"per_child"`
 	// EffectiveSubject identifies the runtime child partition for a per-child
 	// rule. It is never persisted or exposed as part of the rule definition.
 	EffectiveSubject string    `json:"-" bson:"-"`
@@ -121,13 +126,24 @@ func modelSubjectMatches(subject, provider, model string) bool {
 		strings.EqualFold(subject, model[len(prefix):])
 }
 
+// DisplaySubject spells the subject the way the rule was written. Provider
+// and model subjects are matched case-insensitively and stored folded, so the
+// folded key must never be the one shown to clients: it can name a provider
+// that appears in no configuration.
+func (r Rule) DisplaySubject() string {
+	if display := strings.TrimSpace(r.SubjectDisplay); display != "" {
+		return display
+	}
+	return r.Subject
+}
+
 // SubjectLabel names the rule subject for error messages and logs.
 func (r Rule) SubjectLabel() string {
 	switch r.Scope {
 	case ScopeProvider:
-		return "provider " + r.Subject
+		return "provider " + r.DisplaySubject()
 	case ScopeModel:
-		return "model " + r.Subject
+		return "model " + r.DisplaySubject()
 	default:
 		if r.EffectiveSubject != "" {
 			return r.EffectiveSubject
@@ -250,17 +266,35 @@ func NormalizeSubject(scope RuleScope, subject string) (string, error) {
 	}
 }
 
+// subjectDisplayForm keeps the written spelling only when it differs from the
+// stored key by case alone; anything else (a normalized user path, a subject
+// the caller did not supply) leaves no display form to store.
+func subjectDisplayForm(subject, raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == subject || !strings.EqualFold(raw, subject) {
+		return ""
+	}
+	return raw
+}
+
 func NormalizeRule(r Rule) (Rule, error) {
 	scope, err := NormalizeScope(string(r.Scope))
 	if err != nil {
 		return Rule{}, err
 	}
 	r.Scope = scope
+	rawSubject := r.Subject
+	if display := strings.TrimSpace(r.SubjectDisplay); display != "" {
+		// Callers that normalized the subject themselves (the admin API, the
+		// config seeder) pass the original spelling here.
+		rawSubject = display
+	}
 	subject, err := NormalizeSubject(scope, r.Subject)
 	if err != nil {
 		return Rule{}, err
 	}
 	r.Subject = subject
+	r.SubjectDisplay = subjectDisplayForm(subject, rawSubject)
 	r.EffectiveSubject = ""
 	if r.PerChild && scope != ScopeUserPath {
 		return Rule{}, fmt.Errorf("per_child is only valid for user_path rules")

--- a/internal/ratelimit/types_test.go
+++ b/internal/ratelimit/types_test.go
@@ -150,6 +150,81 @@ func TestExceededErrorMessages(t *testing.T) {
 	}
 }
 
+// Provider and model subjects are case-folded to stay the match key, but the
+// spelling the rule was written with is what clients and logs must see: the
+// folded form can name no configured provider at all.
+func TestRuleDisplaySubject(t *testing.T) {
+	tests := []struct {
+		name        string
+		rule        Rule
+		wantSubject string
+		wantDisplay string
+		wantLabel   string
+	}{
+		{
+			name:        "provider keeps the written spelling",
+			rule:        Rule{Scope: ScopeProvider, Subject: "mockA", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
+			wantSubject: "mocka",
+			wantDisplay: "mockA",
+			wantLabel:   "provider mockA",
+		},
+		{
+			name:        "model keeps the written spelling",
+			rule:        Rule{Scope: ScopeModel, Subject: "OpenAI/GPT-4o", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(10))},
+			wantSubject: "openai/gpt-4o",
+			wantDisplay: "OpenAI/GPT-4o",
+			wantLabel:   "model OpenAI/GPT-4o",
+		},
+		{
+			name:        "already folded stores no display form",
+			rule:        Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
+			wantSubject: "openai",
+			wantDisplay: "",
+			wantLabel:   "provider openai",
+		},
+		{
+			name:        "user path is not folded",
+			rule:        Rule{Scope: ScopeUserPath, Subject: "/Team/Alpha", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
+			wantSubject: "/Team/Alpha",
+			wantDisplay: "",
+			wantLabel:   "/Team/Alpha",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, err := NormalizeRule(tt.rule)
+			if err != nil {
+				t.Fatalf("NormalizeRule() failed: %v", err)
+			}
+			if normalized.Subject != tt.wantSubject {
+				t.Fatalf("Subject = %q, want %q", normalized.Subject, tt.wantSubject)
+			}
+			if normalized.SubjectDisplay != tt.wantDisplay {
+				t.Fatalf("SubjectDisplay = %q, want %q", normalized.SubjectDisplay, tt.wantDisplay)
+			}
+			if got := normalized.SubjectLabel(); got != tt.wantLabel {
+				t.Fatalf("SubjectLabel() = %q, want %q", got, tt.wantLabel)
+			}
+			breach := &ExceededError{Rule: normalized, Scope: ScopeRequests, Limit: 1}
+			if !strings.Contains(breach.Error(), tt.wantLabel) {
+				t.Fatalf("breach message %q does not name %q", breach.Error(), tt.wantLabel)
+			}
+		})
+	}
+}
+
+// Rules stored before the display form existed carry none; they degrade to
+// the folded subject instead of reporting nothing.
+func TestRuleDisplaySubjectFallsBackToStoredSubject(t *testing.T) {
+	rule := Rule{Scope: ScopeProvider, Subject: "mocka"}
+	if got := rule.DisplaySubject(); got != "mocka" {
+		t.Fatalf("DisplaySubject() = %q, want %q", got, "mocka")
+	}
+	if got := rule.SubjectLabel(); got != "provider mocka" {
+		t.Fatalf("SubjectLabel() = %q, want %q", got, "provider mocka")
+	}
+}
+
 func TestRuleAppliesToPath(t *testing.T) {
 	tests := []struct {
 		rulePath    string

--- a/internal/server/ratelimit_support.go
+++ b/internal/server/ratelimit_support.go
@@ -198,6 +198,13 @@ func rateLimitBreachHeaders(exceeded *ratelimit.ExceededError) http.Header {
 		headers.Set(rateLimitLimitTokensHeader, limit)
 		headers.Set(rateLimitRemainingTokensHeader, "0")
 		headers.Set(rateLimitResetTokensHeader, reset)
+	case ratelimit.ScopeConcurrency:
+		// An in-flight gauge has no window: the cap and the zero headroom are
+		// well defined, a reset time is not — a slot frees when a request
+		// finishes. Retry-After carries the retry hint instead, so
+		// x-ratelimit-reset-requests is deliberately omitted here.
+		headers.Set(rateLimitLimitRequestsHeader, limit)
+		headers.Set(rateLimitRemainingRequestsHeader, "0")
 	}
 	return headers
 }

--- a/internal/server/ratelimit_support_test.go
+++ b/internal/server/ratelimit_support_test.go
@@ -156,6 +156,49 @@ func TestEnforceRateLimitBreachReturns429WithHeaders(t *testing.T) {
 	}
 }
 
+// A concurrency breach reports the same limit/remaining headers as a window
+// breach; only the reset header is absent, because an in-flight gauge has no
+// window to reset.
+func TestEnforceRateLimitConcurrencyBreachSendsRequestHeaders(t *testing.T) {
+	maxRequests := int64(1)
+	service := newTestRateLimitService(t, ratelimit.Rule{
+		Subject:       "/team",
+		PeriodSeconds: ratelimit.PeriodConcurrent,
+		MaxRequests:   &maxRequests,
+	})
+
+	c, _ := newRateLimitTestContext("/team/alice")
+	release, err := enforceRateLimit(c, service, rateLimitRoute{})
+	if err != nil {
+		t.Fatalf("first enforceRateLimit() error = %v", err)
+	}
+	defer release()
+
+	c2, _ := newRateLimitTestContext("/team/alice")
+	_, err = enforceRateLimit(c2, service, rateLimitRoute{})
+	if err == nil {
+		t.Fatal("second in-flight request admitted, want breach")
+	}
+
+	headerErr, ok := err.(*gatewayErrorWithResponseHeaders)
+	if !ok {
+		t.Fatalf("error %T does not carry response headers", err)
+	}
+	headers := headerErr.ResponseHeaders()
+	if got := headers.Get("x-ratelimit-limit-requests"); got != "1" {
+		t.Fatalf("x-ratelimit-limit-requests = %q, want 1", got)
+	}
+	if got := headers.Get("x-ratelimit-remaining-requests"); got != "0" {
+		t.Fatalf("x-ratelimit-remaining-requests = %q, want 0", got)
+	}
+	if got := headers.Get("x-ratelimit-reset-requests"); got != "" {
+		t.Fatalf("x-ratelimit-reset-requests = %q, want none for a concurrency breach", got)
+	}
+	if got := headers.Get("Retry-After"); got == "" {
+		t.Fatal("Retry-After missing on a concurrency breach")
+	}
+}
+
 func TestEnforceRateLimitDefaultsToRootPath(t *testing.T) {
 	service := newTestRateLimitService(t, rateLimitRuleWithRequests("/", 1))
 


### PR DESCRIPTION
Four small, independent gateway fixes found in exploratory e2e testing.

- **Provider instance naming (G5).** The `502 "provider returned no choices"` (and the empty-response/empty-stream siblings) named the provider *type* from the response body, so two instances of one type (`mockA`/`mockB`, `openai`/`openai-eu`) were indistinguishable. The attempt's configured provider name is now threaded into those errors, matching every other error path.
- **Rate-limit subject spelling (G6).** Provider- and model-scoped subjects are stored case-folded to keep matching case-insensitive, but the folded key was echoed back: a rule created as `mockA` listed and reported as `mocka`, naming no configured provider. Rules now keep a display spelling alongside the match key (new `subject_display` column, added automatically; rules stored before it degrade to the folded value). Matching, delete, and reset stay case-insensitive.
- **Transport-error disclosure (G7).** `504 failed to send request: Post "http://10.0.0.4:8443/v1/chat/completions": ...` handed every authenticated caller the upstream base URL — internal topology, and a token for anyone who embeds one in a custom `base_url`. The full error is now logged server-side; clients get a provider-named summary that still distinguishes timeout / canceled / refused / TLS / DNS, with the same status mapping (504 timeout, 502 otherwise). Same fix for response-read errors.
- **Concurrency 429 headers (G8).** A concurrency-scope breach sent no `x-ratelimit-*` headers although the docs promise them. It now sends `x-ratelimit-limit-requests` and `x-ratelimit-remaining-requests`; `x-ratelimit-reset-requests` stays omitted (an in-flight gauge has no window to reset — `Retry-After` carries the hint) and the docs now say so.

Tested: new table-driven unit tests per fix (`internal/ratelimit`, `internal/server`, `internal/gateway`, `internal/llmclient`), `go test -race` on the touched packages, `make lint`, plus a live gateway against a local mock upstream verifying all four repros before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rate-limit rules now match provider and model names regardless of capitalization while preserving the configured spelling for display.
  - Rate-limit breach responses now include appropriate request, token, and concurrency headers, including retry guidance.
  - Gateway errors identify the specific provider instance that responded.
  - Provider connection and response errors now use clearer, sanitized messages without exposing URLs or credentials.

- **Documentation**
  - Expanded rate-limit documentation to explain case-insensitive matching and response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->