### PR TITLE
fix(audio): forward unknown audio parameters to the provider

### DIFF
--- a/docs/advanced/audio-api.mdx
+++ b/docs/advanced/audio-api.mdx
@@ -171,9 +171,13 @@ back as that provider's own error rather than a silent 200.
 
 Two things never travel: the fields GoModel controls itself (`model`, `file`,
 and the routing hint `provider`, plus the transcription options it re-emits —
-`language`, `prompt`, `response_format`, `temperature`,
+`language`, `prompt`, `response_format`, `temperature`, and both spellings of
 `timestamp_granularities[]`), and extra **file** parts on a transcription
 upload; only the audio in `file` is sent.
+
+Forwarded values are not stored in the [audit log](/advanced/admin-endpoints):
+because they are arbitrary client input that may carry provider credentials,
+the entry records only the field **names** under `forwarded_fields`.
 
 <Note>
   **Streaming is relayed, not streamed.** A forwarded `stream_format: "sse"`

--- a/docs/advanced/audio-api.mdx
+++ b/docs/advanced/audio-api.mdx
@@ -27,6 +27,7 @@ doesn't support audio returns a clear error rather than mis-routing.
 | --- | --- |
 | `POST /v1/audio/speech` | Text-to-speech. Accepts a JSON body and returns **binary audio** in the requested `response_format`. |
 | `POST /v1/audio/transcriptions` | Speech-to-text. Accepts a `multipart/form-data` upload and returns JSON or plain text per `response_format`. |
+| `POST /v1/audio/translations` | Speech-to-English-text. Same upload shape as transcriptions, without `language` and `timestamp_granularities[]`. |
 
 ## Text-to-speech
 
@@ -151,6 +152,43 @@ JSON object; `text`, `srt`, and `vtt` return a `text/plain` body.
   The bracketed `timestamp_granularities[]` form key is canonical, but GoModel
   also accepts the unbracketed `timestamp_granularities` for client compatibility.
 </Tip>
+
+## Parameter forwarding
+
+Any parameter GoModel does not name above is **forwarded to the provider
+unchanged**, so newer OpenAI options and provider-native extras work without
+waiting for a gateway release ([ADR-0011](https://github.com/ENTERPILOT/GoModel/blob/main/docs/adr/0011-field-forwarding-on-translated-paths.md)
+rule 1):
+
+- `/v1/audio/speech` — unknown JSON members (for example `stream_format`) are
+  merged back into the upstream body.
+- `/v1/audio/transcriptions` and `/v1/audio/translations` — unknown form values
+  (for example `include[]=logprobs`, `chunking_strategy`, `stream`) are written
+  into the upstream multipart body, repeated values included.
+
+The provider stays the authority on what it accepts: a field it rejects comes
+back as that provider's own error rather than a silent 200.
+
+Two things never travel: the fields GoModel controls itself (`model`, `file`,
+and the routing hint `provider`, plus the transcription options it re-emits —
+`language`, `prompt`, `response_format`, `temperature`,
+`timestamp_granularities[]`), and extra **file** parts on a transcription
+upload; only the audio in `file` is sent.
+
+<Note>
+  **Streaming is relayed, not streamed.** A forwarded `stream_format: "sse"`
+  (speech) or `stream: true` (transcription) makes the upstream answer with
+  server-sent events, and GoModel returns that body with its
+  `text/event-stream` Content-Type — but the bytes are buffered and delivered
+  in one piece, so a client sees the complete event sequence at the end of the
+  call rather than incrementally.
+</Note>
+
+<Note>
+  Forwarding applies to the OpenAI-compatible upstreams. Providers whose native
+  audio API GoModel translates (Xiaomi MiMo, Cohere, MiniMax, ElevenLabs) build
+  their own request shape and ignore extra parameters.
+</Note>
 
 ## Limitations
 

--- a/docs/providers/xiaomi.mdx
+++ b/docs/providers/xiaomi.mdx
@@ -58,8 +58,11 @@ MiMo has no native `/audio/*` endpoints — TTS (`mimo-v2.5-tts`,
 
 - **Standard audio endpoints** — `/v1/audio/speech` and
   `/v1/audio/transcriptions` are translated automatically. Speech supports
-  `response_format` `wav` (default) and `pcm`; `instructions` become the MiMo
-  style prompt and `voice` selects a preset voice. Transcription supports
+  `response_format` `wav` (default) and `pcm`; `mp3` — OpenAI's documented
+  default, which some SDKs send explicitly — is treated as "unspecified" and
+  answered with WAV, so the response `Content-Type` is `audio/wav`.
+  `instructions` become the MiMo style prompt and `voice` selects a preset
+  voice. Transcription supports
   `json` (default) and `text` response formats, with `language` passed through
   to MiMo's `asr_options` and `temperature` forwarded to the chat request.
 - **MiMo's chat dialect** — send chat completions directly: synthesis text in
@@ -73,8 +76,8 @@ All of these return `invalid_request_error` rather than silently dropping the
 option:
 
 - Embeddings.
-- Speech `response_format` values other than `wav`/`pcm` and non-default
-  `speed` (use `instructions` to adjust pace).
+- Speech `response_format` values other than `wav`/`pcm`/`mp3` (`opus`, `aac`,
+  `flac`) and non-default `speed` (use `instructions` to adjust pace).
 - Transcription `verbose_json`/`srt`/`vtt` formats, `prompt`, and
   `timestamp_granularities` (MiMo returns plain transcript text only).
 

--- a/internal/core/audio.go
+++ b/internal/core/audio.go
@@ -8,7 +8,11 @@ import (
 )
 
 // AudioSpeechRequest is an OpenAI-compatible POST /v1/audio/speech
-// (text-to-speech) request.
+// (text-to-speech) request. Only the fields the gateway needs to route,
+// validate, and audit are typed; every other member (stream_format,
+// model-specific extras, ...) is preserved verbatim in ExtraFields and
+// forwarded upstream so new provider parameters work without a gateway change
+// (ADR-0011 rule 1).
 type AudioSpeechRequest struct {
 	Model          string  `json:"model"`
 	Input          string  `json:"input"`
@@ -19,6 +23,34 @@ type AudioSpeechRequest struct {
 
 	// Provider is gateway routing metadata, stripped before dispatching upstream.
 	Provider string `json:"provider,omitempty"`
+
+	ExtraFields UnknownJSONFields `json:"-" swaggerignore:"true"`
+}
+
+// audioSpeechRequestFields are the typed members of AudioSpeechRequest, derived
+// from the struct so the unknown-field list cannot drift.
+var audioSpeechRequestFields = jsonFieldSetOf(AudioSpeechRequest{})
+
+func (r *AudioSpeechRequest) UnmarshalJSON(data []byte) error {
+	// alias drops UnmarshalJSON so json.Unmarshal does not recurse; ExtraFields
+	// is json:"-" and captured separately.
+	type alias AudioSpeechRequest
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	extraFields, err := extractUnknownJSONFieldsSet(data, audioSpeechRequestFields)
+	if err != nil {
+		return err
+	}
+	*r = AudioSpeechRequest(raw)
+	r.ExtraFields = extraFields
+	return nil
+}
+
+func (r AudioSpeechRequest) MarshalJSON() ([]byte, error) {
+	type alias AudioSpeechRequest
+	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }
 
 // AudioTranscriptionRequest is an OpenAI-compatible POST /v1/audio/transcriptions
@@ -35,9 +67,31 @@ type AudioTranscriptionRequest struct {
 	ResponseFormat         string
 	Temperature            string
 	TimestampGranularities []string
+	// Fields carries the form values the gateway does not consume itself
+	// (include[], chunking_strategy, stream, provider-native extras, ...). They
+	// are forwarded upstream verbatim (ADR-0011 rule 1). Repeated names keep
+	// their relative order; ordering across different names is not preserved
+	// (multipart forms have no cross-field order semantics).
+	Fields []FormField
 
 	// Provider is gateway routing metadata, stripped before dispatching upstream.
 	Provider string
+}
+
+// ReservedAudioTranscriptionFormFields are the multipart fields the gateway
+// consumes and re-emits itself. They never travel in Fields, so a client
+// cannot overwrite a gateway-controlled part (model, file, routing metadata)
+// through the passthrough path.
+var ReservedAudioTranscriptionFormFields = map[string]bool{
+	"model":                     true,
+	"file":                      true,
+	"provider":                  true,
+	"language":                  true,
+	"prompt":                    true,
+	"response_format":           true,
+	"temperature":               true,
+	"timestamp_granularities":   true,
+	"timestamp_granularities[]": true,
 }
 
 // AudioResponse wraps an opaque audio or transcription payload with its content

--- a/internal/core/audio_test.go
+++ b/internal/core/audio_test.go
@@ -1,6 +1,11 @@
 package core
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
 
 func TestSpeechResponseContentType(t *testing.T) {
 	cases := map[string]string{
@@ -49,5 +54,63 @@ func TestDecodeAudioSpeechRequest(t *testing.T) {
 
 	if _, err := DecodeAudioSpeechRequest([]byte(`{"model":`), nil); err == nil {
 		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+// TestAudioSpeechRequest_PreservesUnknownFields covers ADR-0011 rule 1 on
+// /v1/audio/speech: a parameter the gateway has no typed field for (here
+// OpenAI's stream_format) must survive the decode and reach the provider body.
+func TestAudioSpeechRequest_PreservesUnknownFields(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o-mini-tts","input":"hi","voice":"alloy","stream_format":"sse","x_vendor":{"beta":true}}`)
+
+	req, err := DecodeAudioSpeechRequest(body, nil)
+	if err != nil {
+		t.Fatalf("DecodeAudioSpeechRequest() error = %v", err)
+	}
+	if req.Model != "gpt-4o-mini-tts" || req.Input != "hi" || req.Voice != "alloy" {
+		t.Fatalf("typed fields mismatch: %+v", req)
+	}
+	if got := string(req.ExtraFields.Lookup("stream_format")); got != `"sse"` {
+		t.Errorf("stream_format extra = %s, want \"sse\"", got)
+	}
+	if got := string(req.ExtraFields.Lookup("x_vendor")); got != `{"beta":true}` {
+		t.Errorf("x_vendor extra = %s", got)
+	}
+
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var round map[string]any
+	if err := json.Unmarshal(encoded, &round); err != nil {
+		t.Fatalf("Unmarshal(encoded) error = %v", err)
+	}
+	for field, want := range map[string]any{
+		"model": "gpt-4o-mini-tts", "input": "hi", "voice": "alloy", "stream_format": "sse",
+	} {
+		if round[field] != want {
+			t.Errorf("encoded %s = %v, want %v", field, round[field], want)
+		}
+	}
+	// Typed members must not be duplicated into the extras on the way out.
+	if strings.Count(string(encoded), `"model"`) != 1 {
+		t.Errorf("model duplicated in encoded body: %s", encoded)
+	}
+}
+
+// TestAudioSpeechRequest_KnownFieldsAreNotExtras guards the gateway-controlled
+// members: a client cannot smuggle a second model/voice/provider through the
+// passthrough object.
+func TestAudioSpeechRequest_KnownFieldsAreNotExtras(t *testing.T) {
+	req, err := DecodeAudioSpeechRequest([]byte(
+		`{"model":"tts-1","input":"hi","voice":"alloy","instructions":"calm","response_format":"wav","speed":1.5,"provider":"openai"}`), nil)
+	if err != nil {
+		t.Fatalf("DecodeAudioSpeechRequest() error = %v", err)
+	}
+	if !req.ExtraFields.IsEmpty() {
+		t.Fatalf("ExtraFields = %+v, want empty", req.ExtraFields)
+	}
+	if req.ResponseFormat != "wav" || req.Speed != 1.5 || req.Instructions != "calm" || req.Provider != "openai" {
+		t.Fatalf("typed fields mismatch: %+v", req)
 	}
 }

--- a/internal/providers/openai/audio.go
+++ b/internal/providers/openai/audio.go
@@ -99,9 +99,20 @@ func (p *CompatibleProvider) createAudioTranscription(
 		return nil, err
 	}
 	return &core.AudioResponse{
-		ContentType: core.TranscriptionResponseContentType(req.ResponseFormat),
+		ContentType: transcriptionResponseContentType(raw, req.ResponseFormat),
 		Data:        raw.Body,
 	}, nil
+}
+
+// transcriptionResponseContentType keeps the response_format mapping for normal
+// replies, but honors an upstream event-stream type: a forwarded stream=true
+// makes the upstream answer with server-sent events, and labelling those as
+// JSON would leave the client unable to parse them.
+func transcriptionResponseContentType(raw *llmclient.Response, format string) string {
+	if raw != nil && strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw.ContentType)), "text/event-stream") {
+		return raw.ContentType
+	}
+	return core.TranscriptionResponseContentType(format)
 }
 
 // audioTranscriptionMultipart streams a multipart/form-data body for a
@@ -145,6 +156,18 @@ func audioTranscriptionMultipart(req *core.AudioTranscriptionRequest, content io
 					_ = pw.CloseWithError(core.NewInvalidRequestError("failed to write timestamp_granularities field", err))
 					return
 				}
+			}
+		}
+		// Fields the gateway does not consume itself travel verbatim (ADR-0011
+		// rule 1). Gateway-controlled parts are re-checked here so a request
+		// built outside the server layer cannot duplicate model or file.
+		for _, field := range req.Fields {
+			if core.ReservedAudioTranscriptionFormFields[field.Name] {
+				continue
+			}
+			if err := writer.WriteField(field.Name, field.Value); err != nil {
+				_ = pw.CloseWithError(core.NewInvalidRequestError("failed to write "+field.Name+" field", err))
+				return
 			}
 		}
 

--- a/internal/providers/openai/audio_passthrough_test.go
+++ b/internal/providers/openai/audio_passthrough_test.go
@@ -1,0 +1,139 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/goccy/go-json"
+)
+
+// TestCreateTranscription_ForwardsExtraFormFields checks that fields the gateway
+// does not consume itself reach the upstream multipart body unchanged
+// (ADR-0011 rule 1), including repeated values, and that a reserved name cannot
+// be duplicated through the passthrough list.
+func TestCreateTranscription_ForwardsExtraFormFields(t *testing.T) {
+	var got map[string][]string
+	provider := newSpeechTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		got = r.MultipartForm.Value
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"hi"}`))
+	})
+
+	_, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{
+		Model:    "gpt-4o-transcribe",
+		Filename: "speech.wav",
+		File:     []byte("wave-bytes"),
+		Fields: []core.FormField{
+			{Name: "include[]", Value: "logprobs"},
+			{Name: "chunking_strategy", Value: "auto"},
+			{Name: "x_vendor", Value: "a"},
+			{Name: "x_vendor", Value: "b"},
+			// A reserved name must never be re-emitted from the extras.
+			{Name: "model", Value: "evil"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTranscription() error = %v", err)
+	}
+	if want := []string{"logprobs"}; !reflect.DeepEqual(got["include[]"], want) {
+		t.Errorf("include[] = %v, want %v", got["include[]"], want)
+	}
+	if want := []string{"auto"}; !reflect.DeepEqual(got["chunking_strategy"], want) {
+		t.Errorf("chunking_strategy = %v, want %v", got["chunking_strategy"], want)
+	}
+	if want := []string{"a", "b"}; !reflect.DeepEqual(got["x_vendor"], want) {
+		t.Errorf("x_vendor = %v, want %v", got["x_vendor"], want)
+	}
+	if want := []string{"gpt-4o-transcribe"}; !reflect.DeepEqual(got["model"], want) {
+		t.Errorf("model = %v, want %v (extras must not overwrite it)", got["model"], want)
+	}
+}
+
+// TestCreateTranslation_ForwardsExtraFormFields covers the same passthrough on
+// the translations endpoint, which shares the multipart builder.
+func TestCreateTranslation_ForwardsExtraFormFields(t *testing.T) {
+	var got map[string][]string
+	provider := newSpeechTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		got = r.MultipartForm.Value
+		_, _ = w.Write([]byte(`{"text":"hi"}`))
+	})
+
+	_, err := provider.CreateTranslation(context.Background(), &core.AudioTranscriptionRequest{
+		Model:    "whisper-1",
+		Filename: "speech.wav",
+		File:     []byte("wave-bytes"),
+		Fields:   []core.FormField{{Name: "x_vendor", Value: "a"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTranslation() error = %v", err)
+	}
+	if want := []string{"a"}; !reflect.DeepEqual(got["x_vendor"], want) {
+		t.Errorf("x_vendor = %v, want %v", got["x_vendor"], want)
+	}
+}
+
+// TestCreateTranscription_StreamedResponseKeepsEventStreamType ensures a
+// forwarded stream=true is not mislabelled as JSON: the client needs the
+// upstream text/event-stream type to parse the body it gets back.
+func TestCreateTranscription_StreamedResponseKeepsEventStreamType(t *testing.T) {
+	provider := newSpeechTestProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		_, _ = w.Write([]byte("data: {\"type\":\"transcript.text.delta\"}\n\n"))
+	})
+
+	resp, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{
+		Model:    "gpt-4o-transcribe",
+		Filename: "speech.wav",
+		File:     []byte("wave-bytes"),
+		Fields:   []core.FormField{{Name: "stream", Value: "true"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTranscription() error = %v", err)
+	}
+	if resp.ContentType != "text/event-stream; charset=utf-8" {
+		t.Errorf("ContentType = %q, want the upstream event-stream type", resp.ContentType)
+	}
+}
+
+// TestCreateSpeech_ForwardsUnknownJSONFields checks the JSON audio path: an
+// unknown parameter (OpenAI's stream_format) is merged into the upstream body.
+func TestCreateSpeech_ForwardsUnknownJSONFields(t *testing.T) {
+	var body map[string]any
+	provider := newSpeechTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode upstream body: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"speech.audio.delta\"}\n\n"))
+	})
+
+	req, err := core.DecodeAudioSpeechRequest([]byte(
+		`{"model":"gpt-4o-mini-tts","input":"hi","voice":"alloy","stream_format":"sse"}`), nil)
+	if err != nil {
+		t.Fatalf("DecodeAudioSpeechRequest() error = %v", err)
+	}
+	resp, err := provider.CreateSpeech(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CreateSpeech() error = %v", err)
+	}
+	if body["stream_format"] != "sse" {
+		t.Errorf("upstream body = %+v, want stream_format=sse", body)
+	}
+	if body["model"] != "gpt-4o-mini-tts" || body["input"] != "hi" || body["voice"] != "alloy" {
+		t.Errorf("upstream body lost typed fields: %+v", body)
+	}
+	// The upstream answered with a stream; its Content-Type must survive so the
+	// client can parse the events.
+	if resp.ContentType != "text/event-stream" {
+		t.Errorf("ContentType = %q, want text/event-stream", resp.ContentType)
+	}
+}

--- a/internal/providers/openai/audio_passthrough_test.go
+++ b/internal/providers/openai/audio_passthrough_test.go
@@ -81,6 +81,56 @@ func TestCreateTranslation_ForwardsExtraFormFields(t *testing.T) {
 	}
 }
 
+// TestCreateTranscription_HostileFieldNamesKeepMultipartFraming pins the
+// framing guarantee of the passthrough path: a forwarded field name or value is
+// client input, so it must stay inside its own part. Each case would otherwise
+// let a caller graft a second gateway-controlled part onto the upstream body.
+func TestCreateTranscription_HostileFieldNamesKeepMultipartFraming(t *testing.T) {
+	tests := []struct {
+		name  string
+		field core.FormField
+	}{
+		{"crlf in name", core.FormField{
+			Name:  "evil\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nhijacked\r\n",
+			Value: "v",
+		}},
+		{"quote escape promoting to a file part", core.FormField{
+			Name: "x\"; filename=\"boom.txt", Value: "v",
+		}},
+		{"forged boundary in value", core.FormField{
+			Name:  "ok",
+			Value: "v\r\n--boundary\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nhijacked",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var form map[string][]string
+			provider := newSpeechTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseMultipartForm(1 << 20); err != nil {
+					t.Fatalf("upstream could not parse the multipart body: %v", err)
+				}
+				form = r.MultipartForm.Value
+				if len(r.MultipartForm.File) != 1 {
+					t.Errorf("upstream file parts = %d, want only the audio", len(r.MultipartForm.File))
+				}
+				_, _ = w.Write([]byte(`{"text":"hi"}`))
+			})
+
+			if _, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{
+				Model:    "gpt-4o-transcribe",
+				Filename: "speech.wav",
+				File:     []byte("wave-bytes"),
+				Fields:   []core.FormField{tt.field},
+			}); err != nil {
+				t.Fatalf("CreateTranscription() error = %v", err)
+			}
+			if want := []string{"gpt-4o-transcribe"}; !reflect.DeepEqual(form["model"], want) {
+				t.Errorf("model = %v, want %v (the hostile field must not forge a part)", form["model"], want)
+			}
+		})
+	}
+}
+
 // TestCreateTranscription_StreamedResponseKeepsEventStreamType ensures a
 // forwarded stream=true is not mislabelled as JSON: the client needs the
 // upstream text/event-stream type to parse the body it gets back.

--- a/internal/providers/xiaomi/audio.go
+++ b/internal/providers/xiaomi/audio.go
@@ -73,15 +73,19 @@ func (p *Provider) CreateSpeech(ctx context.Context, req *core.AudioSpeechReques
 }
 
 // speechFormat maps an OpenAI response_format to MiMo's audio.format values.
-// MiMo only synthesizes wav and pcm16; wav is the default.
+// MiMo only synthesizes wav and pcm16. "mp3" is OpenAI's documented default, so
+// clients (and SDKs that materialize the default) send it as a synonym for
+// "unspecified"; it is treated like an omitted format and answered with wav
+// rather than a 400. The response Content-Type always describes the bytes
+// actually returned, so a caller that inspects it sees audio/wav.
 func speechFormat(responseFormat string) (format, contentType string, err error) {
 	switch strings.ToLower(strings.TrimSpace(responseFormat)) {
-	case "", "wav":
+	case "", "mp3", "wav":
 		return "wav", "audio/wav", nil
 	case "pcm":
 		return "pcm16", "audio/pcm", nil
 	default:
-		return "", "", core.NewInvalidRequestError("xiaomi supports wav or pcm response formats", nil)
+		return "", "", core.NewInvalidRequestError("xiaomi supports wav or pcm response formats (mp3 is served as wav)", nil)
 	}
 }
 

--- a/internal/providers/xiaomi/audio_test.go
+++ b/internal/providers/xiaomi/audio_test.go
@@ -101,11 +101,40 @@ func TestCreateSpeech_MapsPCMAndRejectsUnsupportedFormats(t *testing.T) {
 		t.Fatalf("upstream body should request pcm16, got: %s", *gotBody)
 	}
 
-	_, err = provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
-		Model: "mimo-v2.5-tts", Input: "hi", ResponseFormat: "mp3",
-	})
-	if err == nil {
-		t.Fatal("CreateSpeech(mp3) succeeded, want unsupported-format error")
+	for _, format := range []string{"opus", "aac", "flac"} {
+		_, err = provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+			Model: "mimo-v2.5-tts", Input: "hi", ResponseFormat: format,
+		})
+		if err == nil {
+			t.Fatalf("CreateSpeech(%s) succeeded, want unsupported-format error", format)
+		}
+	}
+}
+
+// mp3 is OpenAI's documented default, so a client echoing it back is asking for
+// "unspecified" rather than for a codec MiMo cannot synthesize: it is answered
+// with wav, exactly like an omitted response_format.
+func TestCreateSpeech_TreatsMP3AsUnspecified(t *testing.T) {
+	for _, format := range []string{"", "mp3", "MP3", " mp3 ", "wav"} {
+		server, gotBody := newTTSServer(t, base64.StdEncoding.EncodeToString([]byte("wav")))
+		provider := NewWithHTTPClient("mimo-key", server.URL, server.Client(), llmclient.Hooks{})
+
+		resp, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+			Model: "mimo-v2.5-tts", Input: "hi", ResponseFormat: format,
+		})
+		if err != nil {
+			server.Close()
+			t.Fatalf("CreateSpeech(%q) error = %v", format, err)
+		}
+		if resp.ContentType != "audio/wav" {
+			server.Close()
+			t.Fatalf("CreateSpeech(%q) ContentType = %q, want audio/wav", format, resp.ContentType)
+		}
+		if !strings.Contains(string(*gotBody), `"format":"wav"`) {
+			server.Close()
+			t.Fatalf("CreateSpeech(%q) upstream body should request wav, got: %s", format, *gotBody)
+		}
+		server.Close()
 	}
 }
 

--- a/internal/server/audio_passthrough_test.go
+++ b/internal/server/audio_passthrough_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// TestAudioTranscription_ForwardsUnknownFormFields covers ADR-0011 rule 1 on the
+// multipart audio path: form values the gateway does not consume itself (here
+// include[], chunking_strategy and a repeated vendor extra) reach the provider,
+// while the parts the gateway controls stay out of the passthrough list.
+func TestAudioTranscription_ForwardsUnknownFormFields(t *testing.T) {
+	mock := &audioMockProvider{
+		mockProvider:      &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}},
+		transcriptionResp: &core.AudioResponse{ContentType: "application/json", Data: []byte(`{"text":"hi"}`)},
+	}
+	handler := NewHandler(mock, nil, nil, nil)
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for _, field := range [][2]string{
+		{"model", "gpt-4o-transcribe"},
+		{"response_format", "json"},
+		{"prompt", "GoModel"},
+		{"temperature", "0"},
+		{"language", "en"},
+		{"timestamp_granularities[]", "word"},
+		{"include[]", "logprobs"},
+		{"chunking_strategy", "auto"},
+		{"x_vendor", "a"},
+		{"x_vendor", "b"},
+	} {
+		if err := w.WriteField(field[0], field[1]); err != nil {
+			t.Fatalf("WriteField(%s): %v", field[0], err)
+		}
+	}
+	part, err := w.CreateFormFile("file", "speech.mp3")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	_, _ = part.Write([]byte("audio-bytes"))
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &buf)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	if err := handler.AudioTranscriptions(c); err != nil {
+		t.Fatalf("AudioTranscriptions returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	captured := mock.capturedTranscription
+	if captured == nil {
+		t.Fatal("provider was not called")
+	}
+	want := []core.FormField{
+		{Name: "chunking_strategy", Value: "auto"},
+		{Name: "include[]", Value: "logprobs"},
+		{Name: "x_vendor", Value: "a"},
+		{Name: "x_vendor", Value: "b"},
+	}
+	if len(captured.Fields) != len(want) {
+		t.Fatalf("forwarded fields = %+v, want %+v", captured.Fields, want)
+	}
+	for i, field := range want {
+		if captured.Fields[i] != field {
+			t.Errorf("forwarded field %d = %+v, want %+v", i, captured.Fields[i], field)
+		}
+	}
+	// The gateway-owned parts keep their typed home and never travel twice.
+	if captured.Language != "en" || captured.Prompt != "GoModel" || captured.ResponseFormat != "json" {
+		t.Errorf("typed fields mismatch: %+v", captured)
+	}
+}
+
+// TestPassthroughFormFields_SkipsReservedNames pins the exclusion list so a
+// client-supplied value can never overwrite a gateway-controlled multipart part.
+func TestPassthroughFormFields_SkipsReservedNames(t *testing.T) {
+	form := &multipart.Form{Value: map[string][]string{
+		"model": {"evil"}, "file": {"evil"}, "provider": {"evil"},
+		"language": {"en"}, "prompt": {"p"}, "response_format": {"json"},
+		"temperature": {"0"}, "timestamp_granularities": {"word"},
+		"timestamp_granularities[]": {"segment"},
+		"include[]":                 {"logprobs"},
+	}}
+	got := passthroughFormFields(form)
+	if len(got) != 1 || got[0] != (core.FormField{Name: "include[]", Value: "logprobs"}) {
+		t.Fatalf("passthroughFormFields() = %+v, want only include[]", got)
+	}
+	if passthroughFormFields(nil) != nil {
+		t.Error("passthroughFormFields(nil) should be nil")
+	}
+}
+
+// TestAudioSpeech_ForwardsUnknownJSONFields is the JSON half of ADR-0011 rule 1:
+// an unknown speech parameter survives the service layer and reaches the
+// provider request.
+func TestAudioSpeech_ForwardsUnknownJSONFields(t *testing.T) {
+	mock := &audioMockProvider{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
+		speechResp:   &core.AudioResponse{ContentType: "audio/mpeg", Data: []byte("synthetic-audio")},
+	}
+	handler := NewHandler(mock, nil, nil, nil)
+
+	body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy","stream_format":"sse"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	if err := handler.AudioSpeech(c); err != nil {
+		t.Fatalf("AudioSpeech returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.capturedSpeech == nil {
+		t.Fatal("provider was not called")
+	}
+	if got := string(mock.capturedSpeech.ExtraFields.Lookup("stream_format")); got != `"sse"` {
+		t.Errorf("stream_format = %s, want \"sse\"", got)
+	}
+}

--- a/internal/server/audio_passthrough_test.go
+++ b/internal/server/audio_passthrough_test.go
@@ -5,6 +5,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -101,6 +102,34 @@ func TestPassthroughFormFields_SkipsReservedNames(t *testing.T) {
 	}
 	if passthroughFormFields(nil) != nil {
 		t.Error("passthroughFormFields(nil) should be nil")
+	}
+}
+
+// TestAudioTranscriptionAuditInput_RecordsFieldNamesOnly keeps arbitrary
+// client input out of the audit record: a forwarded field may carry a
+// provider-native credential, so only its name is stored.
+func TestAudioTranscriptionAuditInput_RecordsFieldNamesOnly(t *testing.T) {
+	meta := audioTranscriptionAuditInput(&core.AudioTranscriptionRequest{
+		Model:    "gpt-4o-transcribe",
+		Filename: "speech.wav",
+		File:     []byte("audio"),
+		Fields: []core.FormField{
+			{Name: "include[]", Value: "logprobs"},
+			{Name: "x_api_key", Value: "super-secret"},
+			{Name: "x_api_key", Value: "super-secret-2"},
+		},
+	})
+	names, ok := meta["forwarded_fields"].([]string)
+	if !ok || len(names) != 2 || names[0] != "include[]" || names[1] != "x_api_key" {
+		t.Fatalf("forwarded_fields = %v, want the distinct names in request order", meta["forwarded_fields"])
+	}
+	for key, value := range meta {
+		if str, isString := value.(string); isString && strings.Contains(str, "super-secret") {
+			t.Fatalf("audit meta %q leaked a forwarded value: %q", key, str)
+		}
+	}
+	if _, present := meta["x_api_key"]; present {
+		t.Error("forwarded field was recorded as its own audit key")
 	}
 }
 

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -372,12 +372,29 @@ func audioTranscriptionAuditInput(req *core.AudioTranscriptionRequest) map[strin
 	if len(req.TimestampGranularities) > 0 {
 		meta["timestamp_granularities"] = req.TimestampGranularities
 	}
-	for _, field := range req.Fields {
-		if existing, ok := meta[field.Name]; ok {
-			meta[field.Name] = appendAuditValue(existing, field.Value)
-			continue
-		}
-		meta[field.Name] = field.Value
+	// Forwarded fields are arbitrary client input and may carry provider-native
+	// credentials, so the audit entry records only which ones were passed
+	// through, never their values.
+	if names := forwardedFieldNames(req.Fields); len(names) > 0 {
+		meta["forwarded_fields"] = names
 	}
 	return meta
+}
+
+// forwardedFieldNames lists the distinct passthrough field names in request
+// order, for the audit metadata.
+func forwardedFieldNames(fields []core.FormField) []string {
+	if len(fields) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if _, ok := seen[field.Name]; ok {
+			continue
+		}
+		seen[field.Name] = struct{}{}
+		names = append(names, field.Name)
+	}
+	return names
 }

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -241,8 +243,37 @@ func audioTranscriptionRequestFromForm(c *echo.Context, includeTranscriptionFiel
 		ResponseFormat:         strings.TrimSpace(c.FormValue("response_format")),
 		Temperature:            strings.TrimSpace(c.FormValue("temperature")),
 		TimestampGranularities: granularities,
+		Fields:                 passthroughFormFields(form),
 		Provider:               strings.TrimSpace(c.FormValue("provider")),
 	}, nil
+}
+
+// passthroughFormFields collects the form values the gateway does not consume
+// itself so they reach the provider unchanged (ADR-0011 rule 1). Names are
+// sorted for a deterministic upstream body; values sharing a name keep their
+// request order.
+func passthroughFormFields(form *multipart.Form) []core.FormField {
+	if form == nil {
+		return nil
+	}
+	names := make([]string, 0, len(form.Value))
+	for name := range form.Value {
+		if !core.ReservedAudioTranscriptionFormFields[name] {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	sort.Strings(names)
+
+	fields := make([]core.FormField, 0, len(names))
+	for _, name := range names {
+		for _, value := range form.Value[name] {
+			fields = append(fields, core.FormField{Name: name, Value: value})
+		}
+	}
+	return fields
 }
 
 func (s *audioService) respondAudio(c *echo.Context, providerName string, resp *core.AudioResponse) error {
@@ -340,6 +371,13 @@ func audioTranscriptionAuditInput(req *core.AudioTranscriptionRequest) map[strin
 	}
 	if len(req.TimestampGranularities) > 0 {
 		meta["timestamp_granularities"] = req.TimestampGranularities
+	}
+	for _, field := range req.Fields {
+		if existing, ok := meta[field.Name]; ok {
+			meta[field.Name] = appendAuditValue(existing, field.Value)
+			continue
+		}
+		meta[field.Name] = field.Value
 	}
 	return meta
 }


### PR DESCRIPTION
`/v1/audio/*` parsed requests into closed structs, so every parameter outside a fixed allowlist was dropped without an error: `include[]=logprobs`, `chunking_strategy`, `stream` and `stream_format` all vanished and the call still returned 200. ADR-0011 rule 1 (and the image endpoints) say unknown fields are forwarded.

**User-visible impact**

- `/v1/audio/speech`: unknown JSON members are preserved and merged back into the upstream body.
- `/v1/audio/transcriptions` and `/v1/audio/translations`: unknown multipart values (repeats included) are written into the upstream form, sorted by name for a deterministic body.
- Fields the gateway owns (`model`, `file`, `provider`, and the transcription options it re-emits) are never taken from the passthrough list, in the server layer and again in the provider adapter.
- A provider that cannot accept a forwarded field now answers with its own error instead of a silent 200 — e.g. Groq returns `unknown param 'include[]'` (400) where it previously returned a transcription.
- Streaming is **relayed, not streamed**: a forwarded `stream_format: "sse"` / `stream=true` makes the upstream answer with SSE, and that body is returned with its `text/event-stream` Content-Type (previously transcription SSE would have been mislabelled `application/json`), but the bytes are buffered and delivered in one piece. True incremental streaming would need a new raw-streaming provider interface and is not in this PR; the docs say so explicitly.
- Extras reach the OpenAI-compatible upstreams. Providers whose native audio API GoModel translates (Xiaomi, Cohere, MiniMax, ElevenLabs) build their own request shape and ignore them — documented.

**Xiaomi TTS**

`response_format: "mp3"` 400'd while omitting the field succeeded, because MiMo mapped the empty value to `wav`. `mp3` is OpenAI's documented default, so it is now treated as "unspecified" and answered with WAV (`Content-Type: audio/wav`); `opus`/`aac`/`flac` still 400.

**Testing**

`go build ./...`, `go test -race ./...` (only the pre-existing dashboard-asset failures), `make lint`. New table/round-trip tests in `internal/core`, `internal/server`, `internal/providers/openai` and `internal/providers/xiaomi`.

Live against a local gateway: OpenAI `include[]=logprobs` now returns the `logprobs` array (byte-shape identical to the same request sent straight to `api.openai.com`); `stream_format=sse` on speech and `stream=true` on transcription both return `text/event-stream` bodies matching the direct OpenAI responses; `chunking_strategy=auto` passes; Groq relays its own `unknown_param` 400 for a forwarded extra and is unchanged without one; Xiaomi TTS returns `audio/wav` for omitted/`mp3`/`wav`, `audio/pcm` for `pcm`, and 400 for `opus`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Audio speech, transcription, and translation requests now forward supported provider-specific parameters without requiring gateway changes.
  - Multipart fields and repeated values are preserved when forwarded to compatible providers.
  - Streamed transcription responses retain their event-stream content type.

- **Bug Fixes**
  - Xiaomi speech requests using `mp3` now receive WAV audio instead of being rejected.

- **Documentation**
  - Added documentation for audio parameter forwarding and translation support.
  - Updated Xiaomi documentation to describe `mp3` handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->