### PR TITLE
fix(usage): bill media calls by one unit, not two or none

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -8891,6 +8891,60 @@ const docTemplate = `{
                 }
             }
         },
+        "auditlog.GuardrailOutcomeSnapshot": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "Action is the decision (allow, warn, block, respond) or \"failure\" when\nthe instance errored; FailMode then says whether the chain carried on\n(\"open\") or the request failed (\"closed\").",
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "detail": {},
+                "dropped_events": {
+                    "type": "integer"
+                },
+                "duration_ns": {
+                    "type": "integer"
+                },
+                "edited": {
+                    "description": "Edited reports that the instance changed the request (prompt phase)\nor the response (response and stream phases); Target names which.",
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "fail_mode": {
+                    "type": "string"
+                },
+                "instance": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "replaced_events": {
+                    "description": "ReplacedEvents and DroppedEvents count the stream events an in-flight\nstream instance rewrote or withheld.",
+                    "type": "integer"
+                },
+                "seq": {
+                    "type": "integer"
+                },
+                "step": {
+                    "type": "integer"
+                },
+                "target": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "auditlog.LogData": {
             "type": "object",
             "properties": {
@@ -8926,6 +8980,13 @@ const docTemplate = `{
                             "$ref": "#/definitions/auditlog.FailoverSnapshot"
                         }
                     ]
+                },
+                "guardrails": {
+                    "description": "Guardrails records the outcome of every guardrail (plugin instance)\nthat ran for the request, in execution order across the prompt,\nresponse and stream phases: what each decided, whether it edited the\nrequest or response, and how it failed. It is the decision trail;\nRequestRevisions is the body trail. A configured step without an\noutcome did not run (an earlier block, a cache hit).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/auditlog.GuardrailOutcomeSnapshot"
+                    }
                 },
                 "labels": {
                     "description": "Labels are request labels extracted from configured tagging headers.",
@@ -10174,6 +10235,10 @@ const docTemplate = `{
                 "input_per_mtok": {
                     "type": "number"
                 },
+                "output_image_per_mtok": {
+                    "description": "OutputImagePerMtok prices generated image tokens, which providers bill at a\ndifferent rate from text output (OpenAI gpt-image-1: $40/Mtok image output\nand no text output rate at all; Gemini 3 Pro Image: $120/Mtok image output\nversus $12/Mtok text). It is the output rate on the image endpoints.",
+                    "type": "number"
+                },
                 "output_per_mtok": {
                     "type": "number"
                 },
@@ -10181,6 +10246,7 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "per_image": {
+                    "description": "PerImage prices a returned image as a flat unit, for models that report no\ntoken usage at all (DALL·E, Imagen, grok-imagine). It is an alternative\nexpression of the same charge as OutputImagePerMtok, never an addition to\nit: catalog entries carry both, so only one may be applied (see\nusage.CalculateGranularCost).",
                     "type": "number"
                 },
                 "per_page": {
@@ -11090,6 +11156,9 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "input_per_mtok": {
+                    "type": "number"
+                },
+                "output_image_per_mtok": {
                     "type": "number"
                 },
                 "output_per_mtok": {

--- a/docs/advanced/audio-api.mdx
+++ b/docs/advanced/audio-api.mdx
@@ -152,14 +152,41 @@ JSON object; `text`, `srt`, and `vtt` return a `text/plain` body.
   also accepts the unbracketed `timestamp_granularities` for client compatibility.
 </Tip>
 
+## Cost tracking
+
+Every `/v1/audio/*` call is recorded in [usage tracking](/features/cost-tracking)
+under its own endpoint path. Audio models are priced by the unit the provider
+bills, not by tokens:
+
+- **Speech** (`/v1/audio/speech`) records the input character count
+  (`input_characters`, priced with `per_character_input`, as `tts-1` is billed)
+  and the duration of the synthesized audio (`audio_output_seconds`, priced with
+  `per_second_output`, as `gpt-4o-mini-tts` is billed). Duration is measured from
+  the returned `wav`, `pcm`, or `mp3`; other codecs (`opus`, `aac`, `flac`) cannot
+  be measured without decoding, and the row carries a cost caveat saying so.
+- **Transcriptions and translations** are priced by the duration of the uploaded
+  audio (`audio_seconds`, priced with `per_second_input`). GoModel takes the
+  duration the provider reports in `usage.seconds` or `verbose_json`'s
+  `duration`, and otherwise measures the upload itself — so the cost does not
+  depend on the `response_format` the client asked for, and providers that report
+  no usage at all (Groq, ElevenLabs) are still metered.
+- **Token-billed transcription models** (`gpt-4o-transcribe` and similar) report
+  token `usage` and are priced with `input_per_mtok` / `output_per_mtok` instead.
+  A model that publishes both a token rate and a per-second rate is billed by
+  whichever unit the provider reported, never both.
+
+When nothing billable is available — the provider reported no usage and the
+upload is in a container GoModel cannot measure (`m4a`, `ogg`, `flac`, `webm`) —
+the usage row is flagged with a cost-calculation caveat instead of a $0 cost.
+
 ## Limitations
 
 The audio endpoints are a thin, model-routed pass to the provider and **do not run
 through the full inference orchestrator**. Compared with `/v1/chat/completions`:
 
 - **No failover, guardrails, or response cache** — these stages are skipped.
-- **No usage/cost metering** — audio is not token-priced, so it is not recorded in
-  usage tracking. Requests are still authorized, budget-checked, and written to the
+  Requests are still authorized, budget-checked, metered (see
+  [cost tracking](#cost-tracking)), and written to the
   [audit log](/advanced/admin-endpoints) under their `/v1/audio/*` path.
 - **OpenAI request shape in, provider dialect out** — clients always send OpenAI's
   audio format. OpenAI-compatible upstreams receive it unchanged; Xiaomi MiMo,

--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -172,12 +172,14 @@ gateway's request body limit (`BODY_SIZE_LIMIT`).
 Image calls are recorded in [usage tracking](/features/cost-tracking) under the
 `/v1/images/generations` and `/v1/images/edits` endpoints:
 
-A response is billed one of two ways, never both — the reported usage decides:
+The prompt is always priced at `input_per_mtok` when the provider reports input
+tokens. The **generated images** are billed one of two ways, never both — the
+reported usage decides:
 
 - **Token-billed models** (`gpt-image-1`, Gemini image models) report `usage`.
   GoModel stores the token counts and prices the generated tokens with the
-  model's `output_image_per_mtok` rate (falling back to `output_per_mtok`),
-  plus `input_per_mtok` for the prompt. The image output rate is the one
+  model's `output_image_per_mtok` rate (falling back to `output_per_mtok`).
+  The image output rate is the one
   providers charge here: `gpt-image-1` has no text output price at all, and
   Gemini 3 Pro Image bills image output at $120/Mtok against $12/Mtok for text.
   Pricing this way is exact for every size and quality.
@@ -190,10 +192,11 @@ is the flat equivalent of one typical image's tokens ($0.039 for a 1290-token
 `gemini-2.5-flash-image`). A response that reported generated tokens is priced
 by those tokens alone, so the two are never added together.
 
-When the pricing cannot cost the row — no rate for the reported image output
-tokens, or no `usage` block and no `per_image`/`per_request` rate — the usage
-row is flagged with a cost-calculation caveat so it reads as "unreported usage"
-rather than a free call.
+When the pricing cannot cost the generated images — no rate for the image output
+tokens the response reported, or no reported output tokens and no
+`per_image`/`per_request` rate — the usage row is flagged with a
+cost-calculation caveat so it reads as "unreported usage" rather than a free
+call.
 
 Set `per_image` through a [pricing override](/features/cost-tracking#override-pricing)
 or in `config.yaml` when the model catalog has no price for an image model:

--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -172,16 +172,28 @@ gateway's request body limit (`BODY_SIZE_LIMIT`).
 Image calls are recorded in [usage tracking](/features/cost-tracking) under the
 `/v1/images/generations` and `/v1/images/edits` endpoints:
 
-- **Token-billed models** (`gpt-image-1` and similar) report `usage` in the
-  response; GoModel stores the input/output token counts and prices them with the
-  model's `input_per_mtok` / `output_per_mtok` rates.
-- **Per-image models** (DALL·E, `grok-2-image`, Imagen) report no tokens.
+A response is billed one of two ways, never both — the reported usage decides:
+
+- **Token-billed models** (`gpt-image-1`, Gemini image models) report `usage`.
+  GoModel stores the token counts and prices the generated tokens with the
+  model's `output_image_per_mtok` rate (falling back to `output_per_mtok`),
+  plus `input_per_mtok` for the prompt. The image output rate is the one
+  providers charge here: `gpt-image-1` has no text output price at all, and
+  Gemini 3 Pro Image bills image output at $120/Mtok against $12/Mtok for text.
+  Pricing this way is exact for every size and quality.
+- **Per-image models** (DALL·E, `grok-imagine-image`, Imagen) report no tokens.
   GoModel records the number of returned images (`images` in the raw usage
   data) and prices it with the model's `per_image` rate.
-- When a response carries no `usage` block and the configured pricing cannot
-  cost it without one (no `per_image` rate to apply to the returned images, no
-  `per_request` rate), the usage row is flagged with a cost-calculation caveat
-  so it reads as "unreported usage" rather than a free call.
+
+Catalog entries often carry both rates for the same model, because `per_image`
+is the flat equivalent of one typical image's tokens ($0.039 for a 1290-token
+`gemini-2.5-flash-image`). A response that reported generated tokens is priced
+by those tokens alone, so the two are never added together.
+
+When the pricing cannot cost the row — no rate for the reported image output
+tokens, or no `usage` block and no `per_image`/`per_request` rate — the usage
+row is flagged with a cost-calculation caveat so it reads as "unreported usage"
+rather than a free call.
 
 Set `per_image` through a [pricing override](/features/cost-tracking#override-pricing)
 or in `config.yaml` when the model catalog has no price for an image model:

--- a/docs/features/cost-tracking.mdx
+++ b/docs/features/cost-tracking.mdx
@@ -21,7 +21,7 @@ For each request GoModel prices:
 
 - **Input** and **output** tokens at the model's per-million-token (MTok) rates.
 - **Cached input**, **reasoning**, and **audio** tokens at their own rates when the provider reports them, so cache-heavy and reasoning-heavy traffic is priced correctly.
-- **Non-token units** where that is how the provider bills: generated images (`per_image` / `output_image_per_mtok`), audio duration (`per_second_input`, `per_second_output`), and speech characters (`per_character_input`). See [images](/advanced/images-api#cost-tracking) and [audio](/advanced/audio-api#cost-tracking) for which unit applies to which model — a model is priced by one unit, never two at once.
+- **Non-token units** where that is how the provider bills: generated images (`per_image` / `output_image_per_mtok`), audio duration (`per_second_input`, `per_second_output`), and speech characters (`per_character_input`). See [images](/advanced/images-api#cost-tracking) and [audio](/advanced/audio-api#cost-tracking) for which unit applies to which model — where a rate and a token rate are two expressions of the same charge (an image's generated tokens, an audio clip's duration), only one of them is applied.
 
 When a provider returns an exact cost (OpenRouter credits, xAI `cost_in_usd_ticks`), GoModel uses that value instead of catalog pricing. Each row records which method was used in its `cost_source` field: `model_pricing`, `openrouter_credits`, or `xai_cost_in_usd_ticks`.
 

--- a/docs/features/cost-tracking.mdx
+++ b/docs/features/cost-tracking.mdx
@@ -21,6 +21,7 @@ For each request GoModel prices:
 
 - **Input** and **output** tokens at the model's per-million-token (MTok) rates.
 - **Cached input**, **reasoning**, and **audio** tokens at their own rates when the provider reports them, so cache-heavy and reasoning-heavy traffic is priced correctly.
+- **Non-token units** where that is how the provider bills: generated images (`per_image` / `output_image_per_mtok`), audio duration (`per_second_input`, `per_second_output`), and speech characters (`per_character_input`). See [images](/advanced/images-api#cost-tracking) and [audio](/advanced/audio-api#cost-tracking) for which unit applies to which model — a model is priced by one unit, never two at once.
 
 When a provider returns an exact cost (OpenRouter credits, xAI `cost_in_usd_ticks`), GoModel uses that value instead of catalog pricing. Each row records which method was used in its `cost_source` field: `model_pricing`, `openrouter_credits`, or `xai_cost_in_usd_ticks`.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13975,6 +13975,10 @@
           "input_per_mtok": {
             "type": "number"
           },
+          "output_image_per_mtok": {
+            "description": "OutputImagePerMtok prices generated image tokens, which providers bill at a\ndifferent rate from text output (OpenAI gpt-image-1: $40/Mtok image output\nand no text output rate at all; Gemini 3 Pro Image: $120/Mtok image output\nversus $12/Mtok text). It is the output rate on the image endpoints.",
+            "type": "number"
+          },
           "output_per_mtok": {
             "type": "number"
           },
@@ -13982,6 +13986,7 @@
             "type": "number"
           },
           "per_image": {
+            "description": "PerImage prices a returned image as a flat unit, for models that report no\ntoken usage at all (DALL·E, Imagen, grok-imagine). It is an alternative\nexpression of the same charge as OutputImagePerMtok, never an addition to\nit: catalog entries carry both, so only one may be applied (see\nusage.CalculateGranularCost).",
             "type": "number"
           },
           "per_page": {
@@ -14925,6 +14930,9 @@
             "type": "number"
           },
           "input_per_mtok": {
+            "type": "number"
+          },
+          "output_image_per_mtok": {
             "type": "number"
           },
           "output_per_mtok": {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -278,24 +278,34 @@ func AllCategories() []ModelCategory {
 
 // ModelPricing holds pricing information for cost calculation.
 type ModelPricing struct {
-	Currency               string             `json:"currency" yaml:"currency"`
-	InputPerMtok           *float64           `json:"input_per_mtok,omitempty" yaml:"input_per_mtok,omitempty"`
-	OutputPerMtok          *float64           `json:"output_per_mtok,omitempty" yaml:"output_per_mtok,omitempty"`
-	CachedInputPerMtok     *float64           `json:"cached_input_per_mtok,omitempty" yaml:"cached_input_per_mtok,omitempty"`
-	CacheWritePerMtok      *float64           `json:"cache_write_per_mtok,omitempty" yaml:"cache_write_per_mtok,omitempty"`
-	ReasoningOutputPerMtok *float64           `json:"reasoning_output_per_mtok,omitempty" yaml:"reasoning_output_per_mtok,omitempty"`
-	BatchInputPerMtok      *float64           `json:"batch_input_per_mtok,omitempty" yaml:"batch_input_per_mtok,omitempty"`
-	BatchOutputPerMtok     *float64           `json:"batch_output_per_mtok,omitempty" yaml:"batch_output_per_mtok,omitempty"`
-	AudioInputPerMtok      *float64           `json:"audio_input_per_mtok,omitempty" yaml:"audio_input_per_mtok,omitempty"`
-	AudioOutputPerMtok     *float64           `json:"audio_output_per_mtok,omitempty" yaml:"audio_output_per_mtok,omitempty"`
-	PerImage               *float64           `json:"per_image,omitempty" yaml:"per_image,omitempty"`
-	InputPerImage          *float64           `json:"input_per_image,omitempty" yaml:"input_per_image,omitempty"`
-	PerSecondInput         *float64           `json:"per_second_input,omitempty" yaml:"per_second_input,omitempty"`
-	PerSecondOutput        *float64           `json:"per_second_output,omitempty" yaml:"per_second_output,omitempty"`
-	PerCharacterInput      *float64           `json:"per_character_input,omitempty" yaml:"per_character_input,omitempty"`
-	PerRequest             *float64           `json:"per_request,omitempty" yaml:"per_request,omitempty"`
-	PerPage                *float64           `json:"per_page,omitempty" yaml:"per_page,omitempty"`
-	Tiers                  []ModelPricingTier `json:"tiers,omitempty" yaml:"tiers,omitempty"`
+	Currency               string   `json:"currency" yaml:"currency"`
+	InputPerMtok           *float64 `json:"input_per_mtok,omitempty" yaml:"input_per_mtok,omitempty"`
+	OutputPerMtok          *float64 `json:"output_per_mtok,omitempty" yaml:"output_per_mtok,omitempty"`
+	CachedInputPerMtok     *float64 `json:"cached_input_per_mtok,omitempty" yaml:"cached_input_per_mtok,omitempty"`
+	CacheWritePerMtok      *float64 `json:"cache_write_per_mtok,omitempty" yaml:"cache_write_per_mtok,omitempty"`
+	ReasoningOutputPerMtok *float64 `json:"reasoning_output_per_mtok,omitempty" yaml:"reasoning_output_per_mtok,omitempty"`
+	BatchInputPerMtok      *float64 `json:"batch_input_per_mtok,omitempty" yaml:"batch_input_per_mtok,omitempty"`
+	BatchOutputPerMtok     *float64 `json:"batch_output_per_mtok,omitempty" yaml:"batch_output_per_mtok,omitempty"`
+	AudioInputPerMtok      *float64 `json:"audio_input_per_mtok,omitempty" yaml:"audio_input_per_mtok,omitempty"`
+	AudioOutputPerMtok     *float64 `json:"audio_output_per_mtok,omitempty" yaml:"audio_output_per_mtok,omitempty"`
+	// OutputImagePerMtok prices generated image tokens, which providers bill at a
+	// different rate from text output (OpenAI gpt-image-1: $40/Mtok image output
+	// and no text output rate at all; Gemini 3 Pro Image: $120/Mtok image output
+	// versus $12/Mtok text). It is the output rate on the image endpoints.
+	OutputImagePerMtok *float64 `json:"output_image_per_mtok,omitempty" yaml:"output_image_per_mtok,omitempty"`
+	// PerImage prices a returned image as a flat unit, for models that report no
+	// token usage at all (DALL·E, Imagen, grok-imagine). It is an alternative
+	// expression of the same charge as OutputImagePerMtok, never an addition to
+	// it: catalog entries carry both, so only one may be applied (see
+	// usage.CalculateGranularCost).
+	PerImage          *float64           `json:"per_image,omitempty" yaml:"per_image,omitempty"`
+	InputPerImage     *float64           `json:"input_per_image,omitempty" yaml:"input_per_image,omitempty"`
+	PerSecondInput    *float64           `json:"per_second_input,omitempty" yaml:"per_second_input,omitempty"`
+	PerSecondOutput   *float64           `json:"per_second_output,omitempty" yaml:"per_second_output,omitempty"`
+	PerCharacterInput *float64           `json:"per_character_input,omitempty" yaml:"per_character_input,omitempty"`
+	PerRequest        *float64           `json:"per_request,omitempty" yaml:"per_request,omitempty"`
+	PerPage           *float64           `json:"per_page,omitempty" yaml:"per_page,omitempty"`
+	Tiers             []ModelPricingTier `json:"tiers,omitempty" yaml:"tiers,omitempty"`
 	// TimeWindows carry rates that replace the base prices during recurring
 	// UTC windows (see ModelPricingTimeWindow). Base prices are the standard
 	// (peak) rates; use AtTime to resolve the rates in effect at a moment.
@@ -331,6 +341,7 @@ func (p *ModelPricing) FieldSources(source string) map[string]string {
 	add("batch_output_per_mtok", p.BatchOutputPerMtok)
 	add("audio_input_per_mtok", p.AudioInputPerMtok)
 	add("audio_output_per_mtok", p.AudioOutputPerMtok)
+	add("output_image_per_mtok", p.OutputImagePerMtok)
 	add("per_image", p.PerImage)
 	add("input_per_image", p.InputPerImage)
 	add("per_second_input", p.PerSecondInput)
@@ -400,6 +411,7 @@ func (p *ModelPricing) Clone() *ModelPricing {
 	out.BatchOutputPerMtok = cloneFloatPtr(p.BatchOutputPerMtok)
 	out.AudioInputPerMtok = cloneFloatPtr(p.AudioInputPerMtok)
 	out.AudioOutputPerMtok = cloneFloatPtr(p.AudioOutputPerMtok)
+	out.OutputImagePerMtok = cloneFloatPtr(p.OutputImagePerMtok)
 	out.PerImage = cloneFloatPtr(p.PerImage)
 	out.InputPerImage = cloneFloatPtr(p.InputPerImage)
 	out.PerSecondInput = cloneFloatPtr(p.PerSecondInput)

--- a/internal/pricingoverrides/pricing.go
+++ b/internal/pricingoverrides/pricing.go
@@ -15,6 +15,7 @@ func clonePricing(p Pricing) Pricing {
 	out.BatchOutputPerMtok = cloneFloatPtr(p.BatchOutputPerMtok)
 	out.AudioInputPerMtok = cloneFloatPtr(p.AudioInputPerMtok)
 	out.AudioOutputPerMtok = cloneFloatPtr(p.AudioOutputPerMtok)
+	out.OutputImagePerMtok = cloneFloatPtr(p.OutputImagePerMtok)
 	out.PerImage = cloneFloatPtr(p.PerImage)
 	out.InputPerImage = cloneFloatPtr(p.InputPerImage)
 	out.PerSecondInput = cloneFloatPtr(p.PerSecondInput)
@@ -48,6 +49,7 @@ func pricingEmpty(p Pricing) bool {
 		p.BatchOutputPerMtok != nil ||
 		p.AudioInputPerMtok != nil ||
 		p.AudioOutputPerMtok != nil ||
+		p.OutputImagePerMtok != nil ||
 		p.PerImage != nil ||
 		p.InputPerImage != nil ||
 		p.PerSecondInput != nil ||
@@ -85,6 +87,7 @@ func pricingToCore(p Pricing) *core.ModelPricing {
 		BatchOutputPerMtok:     cloneFloatPtr(p.BatchOutputPerMtok),
 		AudioInputPerMtok:      cloneFloatPtr(p.AudioInputPerMtok),
 		AudioOutputPerMtok:     cloneFloatPtr(p.AudioOutputPerMtok),
+		OutputImagePerMtok:     cloneFloatPtr(p.OutputImagePerMtok),
 		PerImage:               cloneFloatPtr(p.PerImage),
 		InputPerImage:          cloneFloatPtr(p.InputPerImage),
 		PerSecondInput:         cloneFloatPtr(p.PerSecondInput),
@@ -126,6 +129,7 @@ func mergePricing(base *core.ModelPricing, override Pricing) *core.ModelPricing 
 	applyFloatOverride(&out.BatchOutputPerMtok, overlay.BatchOutputPerMtok)
 	applyFloatOverride(&out.AudioInputPerMtok, overlay.AudioInputPerMtok)
 	applyFloatOverride(&out.AudioOutputPerMtok, overlay.AudioOutputPerMtok)
+	applyFloatOverride(&out.OutputImagePerMtok, overlay.OutputImagePerMtok)
 	applyFloatOverride(&out.PerImage, overlay.PerImage)
 	applyFloatOverride(&out.InputPerImage, overlay.InputPerImage)
 	applyFloatOverride(&out.PerSecondInput, overlay.PerSecondInput)

--- a/internal/pricingoverrides/types.go
+++ b/internal/pricingoverrides/types.go
@@ -20,6 +20,7 @@ type Pricing struct {
 	BatchOutputPerMtok     *float64      `json:"batch_output_per_mtok,omitempty" bson:"batch_output_per_mtok,omitempty"`
 	AudioInputPerMtok      *float64      `json:"audio_input_per_mtok,omitempty" bson:"audio_input_per_mtok,omitempty"`
 	AudioOutputPerMtok     *float64      `json:"audio_output_per_mtok,omitempty" bson:"audio_output_per_mtok,omitempty"`
+	OutputImagePerMtok     *float64      `json:"output_image_per_mtok,omitempty" bson:"output_image_per_mtok,omitempty"`
 	PerImage               *float64      `json:"per_image,omitempty" bson:"per_image,omitempty"`
 	InputPerImage          *float64      `json:"input_per_image,omitempty" bson:"input_per_image,omitempty"`
 	PerSecondInput         *float64      `json:"per_second_input,omitempty" bson:"per_second_input,omitempty"`

--- a/internal/pricingoverrides/validation.go
+++ b/internal/pricingoverrides/validation.go
@@ -50,6 +50,7 @@ func pricingScalarFields(p Pricing) []pricingField {
 		{"batch_output_per_mtok", p.BatchOutputPerMtok},
 		{"audio_input_per_mtok", p.AudioInputPerMtok},
 		{"audio_output_per_mtok", p.AudioOutputPerMtok},
+		{"output_image_per_mtok", p.OutputImagePerMtok},
 		{"per_image", p.PerImage},
 		{"input_per_image", p.InputPerImage},
 		{"per_second_input", p.PerSecondInput},

--- a/internal/providers/registry_pricing_merge.go
+++ b/internal/providers/registry_pricing_merge.go
@@ -59,6 +59,7 @@ func mergeConfigPricing(base, override *core.ModelPricing) *core.ModelPricing {
 	applyPricingOverride(&merged.BatchOutputPerMtok, override.BatchOutputPerMtok)
 	applyPricingOverride(&merged.AudioInputPerMtok, override.AudioInputPerMtok)
 	applyPricingOverride(&merged.AudioOutputPerMtok, override.AudioOutputPerMtok)
+	applyPricingOverride(&merged.OutputImagePerMtok, override.OutputImagePerMtok)
 	applyPricingOverride(&merged.PerImage, override.PerImage)
 	applyPricingOverride(&merged.InputPerImage, override.InputPerImage)
 	applyPricingOverride(&merged.PerSecondInput, override.PerSecondInput)

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -174,10 +174,12 @@ func (s *audioService) createAudioTranscription(c *echo.Context, translation boo
 		return s.respondAudio(c, route.providerName, resp) // emits the 502 guard before resp.Data is read
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
+		// The uploaded audio backs duration pricing when the provider reports no
+		// usage (whisper text/srt/vtt, Groq, ElevenLabs, every translation).
 		if translation {
-			return usage.ExtractFromTranslationResponse(resp.Data, route.requestID, route.model, route.providerType, pricing)
+			return usage.ExtractFromTranslationResponse(resp.Data, req.File, route.requestID, route.model, route.providerType, pricing)
 		}
-		return usage.ExtractFromTranscriptionResponse(resp.Data, route.requestID, route.model, route.providerType, pricing)
+		return usage.ExtractFromTranscriptionResponse(resp.Data, req.File, route.requestID, route.model, route.providerType, pricing)
 	})
 	if err := waitForModelSlowdownFactor(ctx, route.slowdown, inferenceTime); err != nil {
 		return handleError(c, err)

--- a/internal/server/image_edit_service_test.go
+++ b/internal/server/image_edit_service_test.go
@@ -299,7 +299,9 @@ func TestImageEdits_LogsUsage(t *testing.T) {
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
 	mock := newImageEditMock()
-	pricing := &core.ModelPricing{PerImage: new(0.04)}
+	// gpt-image-1 reports image output tokens, priced at $40/Mtok: the mock's
+	// 1000 output tokens cost $0.04.
+	pricing := &core.ModelPricing{OutputImagePerMtok: new(40.0)}
 	svc := &imageService{
 		provider:        mock,
 		usageLogger:     logger,

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -86,20 +86,21 @@ type transcriptionUsage struct {
 
 // ExtractFromTranscriptionResponse builds a usage entry for a speech-to-text
 // request. The response body is proxied verbatim; when it is JSON it may carry a
-// usage object (token- or duration-based). The entry is always returned so the
-// interaction stays observable even when the provider reports no usage (whisper,
-// or non-JSON response formats such as text/srt/vtt).
-func ExtractFromTranscriptionResponse(body []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
-	return extractFromAudioTextResponse(body, requestID, model, provider, endpointAudioTranscriptions, pricing...)
+// usage object (token- or duration-based) or a verbose_json duration. Providers
+// and response formats that report neither (whisper text/srt/vtt, Groq,
+// ElevenLabs) are priced from the uploaded audio's own duration, so the same
+// call costs the same whatever format it asked for.
+func ExtractFromTranscriptionResponse(body, audio []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
+	return extractFromAudioTextResponse(body, audio, requestID, model, provider, endpointAudioTranscriptions, pricing...)
 }
 
 // ExtractFromTranslationResponse builds a usage entry for an audio translation
 // request while preserving the translations endpoint in usage records.
-func ExtractFromTranslationResponse(body []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
-	return extractFromAudioTextResponse(body, requestID, model, provider, endpointAudioTranslations, pricing...)
+func ExtractFromTranslationResponse(body, audio []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
+	return extractFromAudioTextResponse(body, audio, requestID, model, provider, endpointAudioTranslations, pricing...)
 }
 
-func extractFromAudioTextResponse(body []byte, requestID, model, provider, endpoint string, pricing ...*core.ModelPricing) *UsageEntry {
+func extractFromAudioTextResponse(body, audio []byte, requestID, model, provider, endpoint string, pricing ...*core.ModelPricing) *UsageEntry {
 	entry := &UsageEntry{
 		ID:        uuid.New().String(),
 		RequestID: requestID,
@@ -111,21 +112,46 @@ func extractFromAudioTextResponse(body []byte, requestID, model, provider, endpo
 
 	var parsed struct {
 		Usage *transcriptionUsage `json:"usage"`
+		// Duration is the verbose_json transcript length, which OpenAI and Groq
+		// both report even when they report no usage object at all.
+		Duration any `json:"duration"`
 	}
-	if json.Unmarshal(body, &parsed) == nil && parsed.Usage != nil {
-		u := parsed.Usage
-		entry.InputTokens = u.InputTokens
-		entry.OutputTokens = u.OutputTokens
-		entry.TotalTokens = u.TotalTokens
-		if entry.TotalTokens == 0 {
-			entry.TotalTokens = u.InputTokens + u.OutputTokens
+	var seconds float64
+	if json.Unmarshal(body, &parsed) == nil {
+		if u := parsed.Usage; u != nil {
+			entry.InputTokens = u.InputTokens
+			entry.OutputTokens = u.OutputTokens
+			entry.TotalTokens = u.TotalTokens
+			if entry.TotalTokens == 0 {
+				entry.TotalTokens = u.InputTokens + u.OutputTokens
+			}
+			seconds = u.Seconds
 		}
-		if u.Seconds > 0 {
-			entry.RawData = map[string]any{rawKeyAudioSeconds: u.Seconds}
+	}
+	// A provider that reported tokens has named its own billable unit; duration
+	// is then not a second charge on the same audio (whisper-1 publishes both a
+	// token rate and a per-second rate for it). Otherwise fall back to the
+	// verbose_json duration and finally to the upload the gateway already
+	// holds, so the same call costs the same whether the transcript comes back
+	// as json, text, srt or vtt.
+	if seconds <= 0 && entry.TotalTokens == 0 {
+		if duration, ok := numericFloat(parsed.Duration); ok && duration > 0 {
+			seconds = duration
+		} else if measured, ok := measureUploadDurationSeconds(audio); ok {
+			seconds = measured
 		}
+	}
+	if seconds > 0 {
+		entry.RawData = map[string]any{rawKeyAudioSeconds: seconds}
 	}
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
+	// Nothing billable was reported or measurable: a duration-priced model then
+	// costs $0, which reads as a free call rather than an unrecorded one.
+	if entry.CostsCalculationCaveat == "" && seconds <= 0 && entry.TotalTokens == 0 &&
+		audioDurationAffectsCost(effectiveEndpointPricing(endpoint, pricing...)) {
+		entry.CostsCalculationCaveat = caveatAudioMissingUsage
+	}
 
 	return entry
 }

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -116,7 +116,6 @@ func extractFromAudioTextResponse(body, audio []byte, requestID, model, provider
 		// both report even when they report no usage object at all.
 		Duration any `json:"duration"`
 	}
-	var seconds float64
 	if json.Unmarshal(body, &parsed) == nil {
 		if u := parsed.Usage; u != nil {
 			entry.InputTokens = u.InputTokens
@@ -125,17 +124,19 @@ func extractFromAudioTextResponse(body, audio []byte, requestID, model, provider
 			if entry.TotalTokens == 0 {
 				entry.TotalTokens = u.InputTokens + u.OutputTokens
 			}
-			seconds = u.Seconds
 		}
 	}
-	// A provider that reported tokens has named its own billable unit; duration
-	// is then not a second charge on the same audio (whisper-1 publishes both a
-	// token rate and a per-second rate for it). Otherwise fall back to the
-	// verbose_json duration and finally to the upload the gateway already
-	// holds, so the same call costs the same whether the transcript comes back
-	// as json, text, srt or vtt.
-	if seconds <= 0 && entry.TotalTokens == 0 {
-		if duration, ok := numericFloat(parsed.Duration); ok && duration > 0 {
+	// A provider that reported tokens has named its own billable unit, so the
+	// duration is not a second charge on the same audio (whisper-1 publishes
+	// both a token rate and a per-second rate for it). Otherwise the duration is
+	// the billable unit: the reported one, then the verbose_json duration, then
+	// the upload the gateway already holds — so the same call costs the same
+	// whether the transcript comes back as json, text, srt or vtt.
+	var seconds float64
+	if entry.TotalTokens == 0 {
+		if parsed.Usage != nil && parsed.Usage.Seconds > 0 {
+			seconds = parsed.Usage.Seconds
+		} else if duration, ok := numericFloat(parsed.Duration); ok && duration > 0 {
 			seconds = duration
 		} else if measured, ok := measureUploadDurationSeconds(audio); ok {
 			seconds = measured

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -76,12 +76,24 @@ func ExtractFromSpeechRequest(input string, output []byte, format, requestID, mo
 }
 
 // transcriptionUsage mirrors the optional usage object the gpt-4o transcription
-// models return. It is token-based or duration-based; whisper omits it entirely.
+// models return. Type names the provider's own billable unit ("tokens" or
+// "duration"); whisper omits the object entirely.
 type transcriptionUsage struct {
+	Type         string  `json:"type"`
 	InputTokens  int     `json:"input_tokens"`
 	OutputTokens int     `json:"output_tokens"`
 	TotalTokens  int     `json:"total_tokens"`
 	Seconds      float64 `json:"seconds"`
+}
+
+// tokenBilled reports that the provider named tokens as the billable unit, so
+// the audio duration must not be charged on top of (or instead of) them — even
+// when it reported a zero count.
+func (u *transcriptionUsage) tokenBilled() bool {
+	if u == nil {
+		return false
+	}
+	return u.Type == "tokens" || u.InputTokens+u.OutputTokens+u.TotalTokens > 0
 }
 
 // ExtractFromTranscriptionResponse builds a usage entry for a speech-to-text
@@ -133,7 +145,7 @@ func extractFromAudioTextResponse(body, audio []byte, requestID, model, provider
 	// the upload the gateway already holds — so the same call costs the same
 	// whether the transcript comes back as json, text, srt or vtt.
 	var seconds float64
-	if entry.TotalTokens == 0 {
+	if !parsed.Usage.tokenBilled() {
 		if parsed.Usage != nil && parsed.Usage.Seconds > 0 {
 			seconds = parsed.Usage.Seconds
 		} else if duration, ok := numericFloat(parsed.Duration); ok && duration > 0 {
@@ -150,7 +162,7 @@ func extractFromAudioTextResponse(body, audio []byte, requestID, model, provider
 	// Nothing billable was reported or measurable: a duration-priced model then
 	// costs $0, which reads as a free call rather than an unrecorded one.
 	if entry.CostsCalculationCaveat == "" && seconds <= 0 && entry.TotalTokens == 0 &&
-		audioDurationAffectsCost(effectiveEndpointPricing(endpoint, pricing...)) {
+		audioDurationAffectsCost(effectiveEndpointPricing(endpoint, entry.Timestamp, pricing...)) {
 		entry.CostsCalculationCaveat = caveatAudioMissingUsage
 	}
 

--- a/internal/usage/audio_duration.go
+++ b/internal/usage/audio_duration.go
@@ -32,6 +32,38 @@ func measureSpeechDurationSeconds(data []byte, format string) (float64, bool) {
 	return 0, false
 }
 
+// measureUploadDurationSeconds returns the playback duration of an uploaded
+// transcription or translation file. Unlike synthesized speech, an upload's
+// declared type is whatever the client chose to send, so the container is
+// identified from the bytes themselves (RIFF/WAVE, or an MPEG stream with or
+// without a leading ID3 tag) rather than from the filename or Content-Type.
+// Formats the gateway cannot measure without decoding (m4a, ogg/opus, flac,
+// webm) return ok=false so the caller records a caveat instead of a wrong
+// duration.
+func measureUploadDurationSeconds(audio []byte) (float64, bool) {
+	if len(audio) == 0 {
+		return 0, false
+	}
+	if seconds, ok := wavDurationSeconds(audio); ok {
+		return seconds, true
+	}
+	if looksLikeMP3(audio) {
+		return mp3DurationSeconds(audio)
+	}
+	return 0, false
+}
+
+// looksLikeMP3 reports whether the buffer starts as an MPEG audio stream: an
+// ID3v2 tag, or a frame sync word at the very first byte.
+func looksLikeMP3(data []byte) bool {
+	pos := skipID3v2(data)
+	if pos > 0 {
+		return true
+	}
+	_, _, ok := parseMP3FrameHeader(data)
+	return ok
+}
+
 // normalizeAudioFormat reduces a response_format token or audio MIME type to a
 // bare lowercase codec name (e.g. "audio/wav" -> "wav", "audio/mpeg" -> "mp3").
 func normalizeAudioFormat(format string) string {

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -274,6 +274,23 @@ func TestTranscriptionBillableDuration(t *testing.T) {
 			wantCost: new(2.5),
 		},
 		{
+			// A token-billed response with an empty transcript states a zero
+			// charge; measuring the upload instead would invent one.
+			name:       "zero-count token usage is not re-priced by duration",
+			body:       []byte(`{"text":"","usage":{"type":"tokens","input_tokens":0,"output_tokens":0}}`),
+			audio:      wav,
+			pricing:    &core.ModelPricing{InputPerMtok: new(2.5), PerSecondInput: new(0.0001)},
+			wantCost:   new(0.0),
+			wantCaveat: caveatAudioMissingUsage,
+		},
+		{
+			name:       "a model priced only by audio input tokens is flagged when nothing is measurable",
+			body:       []byte(`{"text":"hi"}`),
+			audio:      []byte("OggS not really measurable"),
+			pricing:    &core.ModelPricing{AudioInputPerMtok: new(6.0)},
+			wantCaveat: caveatAudioMissingUsage,
+		},
+		{
 			name:    "an unpriced model records the duration without a caveat",
 			body:    []byte(`{"text":"hi"}`),
 			audio:   wav,

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -264,6 +264,16 @@ func TestTranscriptionBillableDuration(t *testing.T) {
 			wantCost: new(2.5),
 		},
 		{
+			// A usage object carrying both units must not be charged twice:
+			// whisper-1 publishes a token rate and a per-second rate for the
+			// same audio.
+			name:     "a usage object with tokens and seconds is billed by tokens",
+			body:     []byte(`{"text":"hi","usage":{"input_tokens":1000000,"output_tokens":0,"seconds":9}}`),
+			audio:    wav,
+			pricing:  &core.ModelPricing{InputPerMtok: new(2.5), PerSecondInput: new(0.0001)},
+			wantCost: new(2.5),
+		},
+		{
 			name:    "an unpriced model records the duration without a caveat",
 			body:    []byte(`{"text":"hi"}`),
 			audio:   wav,

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -88,7 +88,7 @@ func TestExtractFromSpeechRequest_CompressedOutputCaveat(t *testing.T) {
 func TestExtractFromTranscriptionResponse_TokenUsage(t *testing.T) {
 	body := []byte(`{"text":"hi","usage":{"type":"tokens","input_tokens":14,"output_tokens":45,"total_tokens":59}}`)
 
-	entry := ExtractFromTranscriptionResponse(body, "req-2", "gpt-4o-transcribe", "openai")
+	entry := ExtractFromTranscriptionResponse(body, nil, "req-2", "gpt-4o-transcribe", "openai")
 	if entry == nil {
 		t.Fatal("expected a usage entry")
 	}
@@ -106,14 +106,14 @@ func TestExtractFromAudioTextResponse_UsesEndpoint(t *testing.T) {
 		{
 			name: "transcription",
 			extract: func() *UsageEntry {
-				return ExtractFromTranscriptionResponse([]byte(`{"text":"hello"}`), "req", "whisper-1", "openai")
+				return ExtractFromTranscriptionResponse([]byte(`{"text":"hello"}`), nil, "req", "whisper-1", "openai")
 			},
 			endpoint: endpointAudioTranscriptions,
 		},
 		{
 			name: "translation",
 			extract: func() *UsageEntry {
-				return ExtractFromTranslationResponse([]byte(`{"text":"hello"}`), "req", "whisper-1", "openai")
+				return ExtractFromTranslationResponse([]byte(`{"text":"hello"}`), nil, "req", "whisper-1", "openai")
 			},
 			endpoint: endpointAudioTranslations,
 		},
@@ -132,7 +132,7 @@ func TestExtractFromAudioTextResponse_UsesEndpoint(t *testing.T) {
 func TestExtractFromTranscriptionResponse_TotalTokensDerived(t *testing.T) {
 	body := []byte(`{"usage":{"input_tokens":10,"output_tokens":20}}`)
 
-	entry := ExtractFromTranscriptionResponse(body, "req", "m", "openai")
+	entry := ExtractFromTranscriptionResponse(body, nil, "req", "m", "openai")
 	if entry.TotalTokens != 30 {
 		t.Errorf("total_tokens = %d, want 30 (derived)", entry.TotalTokens)
 	}
@@ -141,7 +141,7 @@ func TestExtractFromTranscriptionResponse_TotalTokensDerived(t *testing.T) {
 func TestExtractFromTranscriptionResponse_DurationUsage(t *testing.T) {
 	body := []byte(`{"text":"hi","usage":{"type":"duration","seconds":9}}`)
 
-	entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai")
+	entry := ExtractFromTranscriptionResponse(body, nil, "req", "whisper-1", "openai")
 	if entry.TotalTokens != 0 {
 		t.Errorf("duration usage should report no tokens, got %d", entry.TotalTokens)
 	}
@@ -155,7 +155,7 @@ func TestExtractFromTranscriptionResponse_PerSecondCost(t *testing.T) {
 	body := []byte(`{"usage":{"type":"duration","seconds":9}}`)
 	pricing := &core.ModelPricing{PerSecondInput: new(0.0001)}
 
-	entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai", pricing)
+	entry := ExtractFromTranscriptionResponse(body, nil, "req", "whisper-1", "openai", pricing)
 	assertCostPtrNear(t, "input cost", entry.InputCost, 0.0009)
 }
 
@@ -171,7 +171,7 @@ func TestExtractFromTranscriptionResponse_NoUsage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entry := ExtractFromTranscriptionResponse(tt.body, "req", "whisper-1", "openai")
+			entry := ExtractFromTranscriptionResponse(tt.body, nil, "req", "whisper-1", "openai")
 			if entry == nil {
 				t.Fatal("expected an entry")
 			}
@@ -186,6 +186,120 @@ func TestExtractFromTranscriptionResponse_TokenCost(t *testing.T) {
 	body := []byte(`{"usage":{"input_tokens":1000000,"output_tokens":0,"total_tokens":1000000}}`)
 	pricing := &core.ModelPricing{InputPerMtok: new(2.5)}
 
-	entry := ExtractFromTranscriptionResponse(body, "req", "gpt-4o-transcribe", "openai", pricing)
+	entry := ExtractFromTranscriptionResponse(body, nil, "req", "gpt-4o-transcribe", "openai", pricing)
 	assertCostPtrNear(t, "input cost", entry.InputCost, 2.5)
+}
+
+// TestTranscriptionBillableDuration pins the rule that the billable unit of a
+// transcription is the audio's duration, however the provider reports it — and
+// however the client asked for the transcript. response_format decides the
+// shape of the body, never the price.
+func TestTranscriptionBillableDuration(t *testing.T) {
+	// whisper-1: $0.0001 per input second.
+	pricing := &core.ModelPricing{PerSecondInput: new(0.0001)}
+	wav := buildWAV(t, 24000, 1, 16, 2.5)
+
+	tests := []struct {
+		name        string
+		body        []byte
+		audio       []byte
+		pricing     *core.ModelPricing
+		wantSeconds float64
+		wantCost    *float64
+		wantCaveat  string
+	}{
+		{
+			name:        "usage seconds are authoritative",
+			body:        []byte(`{"text":"hi","usage":{"type":"duration","seconds":3}}`),
+			audio:       wav,
+			pricing:     pricing,
+			wantSeconds: 3,
+			wantCost:    new(0.0003),
+		},
+		{
+			name:        "verbose_json duration is used when usage is absent",
+			body:        []byte(`{"text":"hi","duration":2.5,"segments":[]}`),
+			audio:       nil,
+			pricing:     pricing,
+			wantSeconds: 2.5,
+			wantCost:    new(0.00025),
+		},
+		{
+			name:        "a plain text transcript is priced from the uploaded audio",
+			body:        []byte("hi"),
+			audio:       wav,
+			pricing:     pricing,
+			wantSeconds: 2.5,
+			wantCost:    new(0.00025),
+		},
+		{
+			name:        "an srt transcript costs the same as json",
+			body:        []byte("1\n00:00:00,000 --> 00:00:02,500\nhi\n"),
+			audio:       wav,
+			pricing:     pricing,
+			wantSeconds: 2.5,
+			wantCost:    new(0.00025),
+		},
+		{
+			name:        "a provider that reports nothing is priced from the upload",
+			body:        []byte(`{"text":"hi"}`),
+			audio:       buildMP3(100),
+			pricing:     &core.ModelPricing{PerSecondInput: new(0.00001111)},
+			wantSeconds: 100 * mp3FrameSeconds,
+			wantCost:    new(100 * mp3FrameSeconds * 0.00001111),
+		},
+		{
+			name:       "an unmeasurable upload with no reported usage is flagged",
+			body:       []byte(`{"text":"hi"}`),
+			audio:      []byte("OggS not really measurable"),
+			pricing:    pricing,
+			wantCaveat: caveatAudioMissingUsage,
+		},
+		{
+			name:    "a token-billed model keeps its token costs",
+			body:    []byte(`{"text":"hi","usage":{"type":"tokens","input_tokens":1000000,"output_tokens":0}}`),
+			audio:   wav,
+			pricing: &core.ModelPricing{InputPerMtok: new(2.5)},
+			// Tokens are the reported billable unit; no duration is recorded.
+			wantCost: new(2.5),
+		},
+		{
+			name:    "an unpriced model records the duration without a caveat",
+			body:    []byte(`{"text":"hi"}`),
+			audio:   wav,
+			pricing: nil,
+
+			wantSeconds: 2.5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, extract := range []func() *UsageEntry{
+				func() *UsageEntry {
+					return ExtractFromTranscriptionResponse(tt.body, tt.audio, "req", "m", "openai", tt.pricing)
+				},
+				func() *UsageEntry {
+					return ExtractFromTranslationResponse(tt.body, tt.audio, "req", "m", "openai", tt.pricing)
+				},
+			} {
+				entry := extract()
+				seconds, _ := extractFloat(entry.RawData, rawKeyAudioSeconds)
+				if !costsNearlyEqual(seconds, tt.wantSeconds) {
+					t.Errorf("audio_seconds = %v, want %v", seconds, tt.wantSeconds)
+				}
+				switch {
+				case tt.wantCost == nil && entry.TotalCost != nil:
+					t.Errorf("total cost = %v, want nil", *entry.TotalCost)
+				case tt.wantCost != nil && entry.TotalCost == nil:
+					t.Errorf("total cost = nil, want %v", *tt.wantCost)
+				case tt.wantCost != nil && !costsNearlyEqual(*entry.TotalCost, *tt.wantCost):
+					t.Errorf("total cost = %v, want %v", *entry.TotalCost, *tt.wantCost)
+				}
+				if entry.CostsCalculationCaveat != tt.wantCaveat {
+					t.Errorf("caveat = %q, want %q", entry.CostsCalculationCaveat, tt.wantCaveat)
+				}
+			}
+		})
+	}
 }

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -68,8 +68,11 @@ func audioDurationAffectsCost(pricing *core.ModelPricing) bool {
 	if pricing == nil || pricing.PerRequest != nil {
 		return false
 	}
-	if pricing.PerSecondInput != nil && *pricing.PerSecondInput != 0 {
-		return true
+	rates := []*float64{pricing.PerSecondInput, pricing.AudioInputPerMtok, pricing.AudioOutputPerMtok}
+	for _, rate := range rates {
+		if rate != nil && *rate != 0 {
+			return true
+		}
 	}
 	return tokenRatesAffectCost(pricing)
 }

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -23,27 +23,55 @@ const (
 // ticks equals 1 USD.
 const xaiUSDTicksPerUSD = 10_000_000_000
 
-// Missing-usage caveats mark rows whose provider reported no usage at all;
-// they describe the usage report, not the price math, so pricing
-// recalculation preserves them (see retainedMissingUsageCaveat).
+// Uncalculated-cost caveats mark rows the configured pricing could not cost:
+// the provider reported no usage, or reported a quantity with no rate to price
+// it. They describe the billable quantity, not the price math, so pricing
+// recalculation preserves them until new pricing closes the gap (see
+// retainedMissingUsageCaveat).
 const (
 	caveatImageMissingUsage     = "provider returned no token usage; set a per_image price to cost this model"
+	caveatImageUnpricedOutput   = "provider reported image output tokens with no configured rate; cost not calculated"
 	caveatEmbeddingMissingUsage = "provider reported no token usage; cost not calculated"
+	caveatAudioMissingUsage     = "provider reported no usage and audio duration could not be measured; cost not calculated"
 )
 
-// imageCostDetermined reports whether pricing can cost an image row whose
-// provider reported no usage: a per_image rate is not a basis on its own,
-// there must also be images to multiply it by. An explicit zero rate counts —
-// a deliberately free model is a known price, not a missing one. A per-request
-// rate stands alone, since it does not depend on reported usage at all.
-func imageCostDetermined(pricing *core.ModelPricing, imageCount int) bool {
-	if pricing == nil {
+// imageCostCaveat reports the caveat an image row needs, or "" when the
+// configured pricing costs it. An image response is billed one of two ways:
+// by the generated image tokens the provider reported, or — when it reported
+// none — by the number of images returned, each needing its own rate. An
+// explicit zero rate counts as priced: a deliberately free model is a known
+// price, not a missing one. A per-request rate stands alone, since it does not
+// depend on reported usage at all.
+//
+// pricing must already be resolved for the image endpoint (see
+// pricingForImageEndpoint), so OutputPerMtok is the image output rate.
+func imageCostCaveat(pricing *core.ModelPricing, outputTokens, imageCount int) string {
+	if pricing != nil && pricing.PerRequest != nil {
+		return ""
+	}
+	if outputTokens > 0 {
+		if pricing != nil && pricing.OutputPerMtok != nil {
+			return ""
+		}
+		return caveatImageUnpricedOutput
+	}
+	if imageCount > 0 && pricing != nil && pricing.PerImage != nil {
+		return ""
+	}
+	return caveatImageMissingUsage
+}
+
+// audioDurationAffectsCost reports whether a transcription or translation row
+// with no reported usage is understated: its model is priced by input audio
+// duration (or by tokens), and neither quantity is available.
+func audioDurationAffectsCost(pricing *core.ModelPricing) bool {
+	if pricing == nil || pricing.PerRequest != nil {
 		return false
 	}
-	if pricing.PerRequest != nil {
+	if pricing.PerSecondInput != nil && *pricing.PerSecondInput != 0 {
 		return true
 	}
-	return imageCount > 0 && pricing.PerImage != nil
+	return tokenRatesAffectCost(pricing)
 }
 
 // tokenRatesAffectCost reports whether reported token usage would have changed
@@ -78,16 +106,22 @@ func tokenRatesAffectCost(pricing *core.ModelPricing) bool {
 // retainedMissingUsageCaveat keeps a stored missing-usage caveat across
 // repricing: recalculation cannot conjure usage the provider never reported.
 // A caveat lifts once the new pricing determines the cost without that usage.
-func retainedMissingUsageCaveat(existing string, rawData map[string]any, pricing *core.ModelPricing) string {
+func retainedMissingUsageCaveat(existing string, outputTokens int, rawData map[string]any, pricing *core.ModelPricing) string {
 	// A prior recalculation may have joined the missing-usage caveat with its
 	// own caveats, so match by containment and return the canonical constant —
 	// the caller re-joins it with the fresh recalculation caveats.
 	switch {
-	case strings.Contains(existing, caveatImageMissingUsage):
-		if imageCostDetermined(pricing, extractInt(rawData, rawKeyImages)) {
+	case strings.Contains(existing, caveatImageMissingUsage),
+		strings.Contains(existing, caveatImageUnpricedOutput):
+		return imageCostCaveat(pricing, outputTokens, extractInt(rawData, rawKeyImages))
+	case strings.Contains(existing, caveatAudioMissingUsage):
+		if _, ok := extractFloat(rawData, rawKeyAudioSeconds); ok {
 			return ""
 		}
-		return caveatImageMissingUsage
+		if !audioDurationAffectsCost(pricing) {
+			return ""
+		}
+		return caveatAudioMissingUsage
 	case strings.Contains(existing, caveatEmbeddingMissingUsage):
 		if !tokenRatesAffectCost(pricing) {
 			return ""
@@ -300,11 +334,14 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 		mappedKeys[rawKeyAudioOutputSeconds] = true
 	}
 
-	// Price generated images for per-image models (DALL·E). The count lives in
-	// RawData (see usage/images.go); token-billed image models carry no
-	// PerImage rate and are priced through the token paths above.
+	// Price generated images for per-image models (DALL·E, Imagen, grok-imagine).
+	// The count lives in RawData (see usage/images.go). PerImage and the output
+	// token rate are two expressions of the same charge — the catalog carries
+	// both for Gemini image models and gpt-image-1, where per_image is just the
+	// token price of one typical image — so a response that reported generated
+	// tokens is priced by tokens alone and never also per image.
 	if pricing.PerImage != nil {
-		if count := extractInt(rawData, rawKeyImages); count > 0 {
+		if count := extractInt(rawData, rawKeyImages); count > 0 && outputTokens <= 0 {
 			outputCost += float64(count) * *pricing.PerImage
 			hasOutput = true
 		}

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -375,6 +375,9 @@ func pricingForEndpoint(pricing *core.ModelPricing, endpoint string) *core.Model
 	if pricing == nil {
 		return nil
 	}
+	if isImageEndpoint(endpoint) {
+		return pricingForImageEndpoint(pricing)
+	}
 	if endpoint != "/v1/batches" && !strings.HasPrefix(endpoint, "/v1/batches/") {
 		return pricing
 	}

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -203,7 +203,7 @@ func ExtractFromEmbeddingResponse(resp *core.EmbeddingResponse, requestID, provi
 	// per-request price, or an explicit zero rate), where the recorded cost is
 	// correct and calling it uncalculated would be false.
 	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 &&
-		tokenRatesAffectCost(effectiveEndpointPricing(endpoint, pricing...)) &&
+		tokenRatesAffectCost(effectiveEndpointPricing(endpoint, entry.Timestamp, pricing...)) &&
 		entry.CostsCalculationCaveat == "" {
 		entry.CostsCalculationCaveat = caveatEmbeddingMissingUsage
 	}
@@ -362,13 +362,15 @@ func normalizeCachedResponseEndpoint(endpoint string) string {
 	return cleaned
 }
 
-// effectiveEndpointPricing resolves the pricing that applies to endpoint, or
-// nil when the caller supplied none.
-func effectiveEndpointPricing(endpoint string, pricing ...*core.ModelPricing) *core.ModelPricing {
+// effectiveEndpointPricing resolves the pricing that applies to endpoint at the
+// entry's timestamp, or nil when the caller supplied none. It matches what
+// applyUsageCosts priced the entry with, so caveat checks read the same rates
+// the cost came from (time-of-day windows included).
+func effectiveEndpointPricing(endpoint string, at time.Time, pricing ...*core.ModelPricing) *core.ModelPricing {
 	if len(pricing) == 0 {
 		return nil
 	}
-	return pricingForEndpoint(pricing[0], endpoint)
+	return pricingForEndpoint(pricing[0].AtTime(at), endpoint)
 }
 
 func pricingForEndpoint(pricing *core.ModelPricing, endpoint string) *core.ModelPricing {

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -1015,7 +1015,7 @@ func TestExtractFromEmbeddingResponse_NoUsageCaveat(t *testing.T) {
 	if unreported.CostsCalculationCaveat != caveatEmbeddingMissingUsage {
 		t.Fatalf("caveat = %q, want %q for a zero base rate with a priced tier", unreported.CostsCalculationCaveat, caveatEmbeddingMissingUsage)
 	}
-	if retained := retainedMissingUsageCaveat(caveatEmbeddingMissingUsage, nil, tiered); retained != caveatEmbeddingMissingUsage {
+	if retained := retainedMissingUsageCaveat(caveatEmbeddingMissingUsage, 0, nil, tiered); retained != caveatEmbeddingMissingUsage {
 		t.Fatalf("repricing retained %q, want the caveat kept for tiered token rates", retained)
 	}
 }

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -75,13 +75,41 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	}
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
-	// A response without a usage block cannot be costed by token rates, and
-	// zero-token math quietly yields $0 — indistinguishable from a free call.
-	// Flag that unless the configured pricing can cost the row without usage.
-	if resp.Usage == nil && entry.CostsCalculationCaveat == "" &&
-		!imageCostDetermined(effectiveEndpointPricing(endpoint, pricing...), len(resp.Data)) {
-		entry.CostsCalculationCaveat = caveatImageMissingUsage
+	// Zero-token math and an unpriced token count both yield $0 quietly —
+	// indistinguishable from a free call. Flag whichever gap applies, so the row
+	// reads as "we could not price this" rather than as a cheap call.
+	if entry.CostsCalculationCaveat == "" {
+		entry.CostsCalculationCaveat = imageCostCaveat(
+			effectiveEndpointPricing(endpoint, pricing...), entry.OutputTokens, len(resp.Data))
 	}
 
 	return entry
+}
+
+// isImageEndpoint reports whether an endpoint prices image output.
+func isImageEndpoint(endpoint string) bool {
+	return endpoint == endpointImageGenerations || endpoint == endpointImageEdits
+}
+
+// pricingForImageEndpoint resolves the output rate that applies to an image
+// generation or edit: everything the model returns there is image output, which
+// providers bill at output_image_per_mtok rather than the text output rate
+// (gpt-image-1 has no text output rate at all, and Gemini 3 Pro Image charges
+// $120/Mtok for image output against $12/Mtok for text).
+func pricingForImageEndpoint(pricing *core.ModelPricing) *core.ModelPricing {
+	if pricing == nil || pricing.OutputImagePerMtok == nil {
+		return pricing
+	}
+	effective := *pricing
+	effective.OutputPerMtok = pricing.OutputImagePerMtok
+	// Volume tiers publish text rates; image output is billed at the image rate
+	// whatever tier the input lands in.
+	if len(pricing.Tiers) > 0 {
+		effective.Tiers = make([]core.ModelPricingTier, len(pricing.Tiers))
+		copy(effective.Tiers, pricing.Tiers)
+		for i := range effective.Tiers {
+			effective.Tiers[i].OutputPerMtok = nil
+		}
+	}
+	return &effective
 }

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -80,7 +80,7 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	// reads as "we could not price this" rather than as a cheap call.
 	if entry.CostsCalculationCaveat == "" {
 		entry.CostsCalculationCaveat = imageCostCaveat(
-			effectiveEndpointPricing(endpoint, pricing...), entry.OutputTokens, len(resp.Data))
+			effectiveEndpointPricing(endpoint, entry.Timestamp, pricing...), entry.OutputTokens, len(resp.Data))
 	}
 
 	return entry

--- a/internal/usage/images_test.go
+++ b/internal/usage/images_test.go
@@ -94,7 +94,10 @@ func TestExtractFromImageEditResponse(t *testing.T) {
 			InputTokensDetails: &core.ImageTokenDetails{TextTokens: 10, ImageTokens: 40},
 		},
 	}
-	pricing := &core.ModelPricing{PerImage: new(0.04)}
+	// gpt-image-1 prices generated image tokens at $40/Mtok and publishes
+	// per_image as the flat equivalent of one high-quality image; the reported
+	// tokens decide, so the edit costs 1000 * 40 / 1e6.
+	pricing := &core.ModelPricing{OutputImagePerMtok: new(40.0), PerImage: new(0.167)}
 
 	entry := ExtractFromImageEditResponse(resp, "req-2", "gpt-image-1", "openai", pricing)
 
@@ -111,7 +114,110 @@ func TestExtractFromImageEditResponse(t *testing.T) {
 		t.Errorf("raw data = %v", entry.RawData)
 	}
 	if entry.OutputCost == nil || !costsNearlyEqual(*entry.OutputCost, 0.04) {
-		t.Errorf("output cost = %v, want 0.04 per-image", entry.OutputCost)
+		t.Errorf("output cost = %v, want 0.04 from image output tokens", entry.OutputCost)
+	}
+}
+
+// TestImageBillingUnit pins the rule that decides how an image call is priced:
+// a response that reports generated tokens is billed by those tokens at the
+// image output rate, and only a response that reports none is billed per
+// image. The catalog carries both rates for the same model (Gemini image
+// models, gpt-image-1), where per_image is just the token price of one typical
+// image, so applying both double-bills.
+func TestImageBillingUnit(t *testing.T) {
+	// gemini-2.5-flash-image: $0.30/Mtok in, $30/Mtok image out, and a
+	// per_image of $0.039 — the price of one 1290-token image.
+	gemini := &core.ModelPricing{
+		InputPerMtok:       new(0.3),
+		OutputPerMtok:      new(30.0),
+		OutputImagePerMtok: new(30.0),
+		PerImage:           new(0.039),
+	}
+	// gpt-image-1 has no text output rate at all: image tokens cost $40/Mtok,
+	// and per_image is the flat price of a high-quality 1024x1024.
+	gptImage1 := &core.ModelPricing{
+		InputPerMtok:       new(5.0),
+		OutputImagePerMtok: new(40.0),
+		PerImage:           new(0.167),
+	}
+	// gpt-image-1-mini publishes only an image output rate.
+	gptImage1Mini := &core.ModelPricing{InputPerMtok: new(2.0), OutputImagePerMtok: new(8.0)}
+	// dall-e-3 reports no usage at all and is billed per image.
+	dalle := &core.ModelPricing{PerImage: new(0.04)}
+
+	tests := []struct {
+		name       string
+		pricing    *core.ModelPricing
+		usage      *core.ImageUsage
+		images     int
+		wantCost   *float64
+		wantCaveat string
+	}{
+		{
+			name:     "gemini token-billed image is not also billed per image",
+			pricing:  gemini,
+			usage:    &core.ImageUsage{InputTokens: 5, OutputTokens: 1290, TotalTokens: 1295},
+			images:   1,
+			wantCost: new(5*0.3/1e6 + 1290*30/1e6),
+		},
+		{
+			name:     "gpt-image-1 low quality is billed by its image tokens",
+			pricing:  gptImage1,
+			usage:    &core.ImageUsage{InputTokens: 9, OutputTokens: 272},
+			images:   1,
+			wantCost: new(9*5/1e6 + 272*40/1e6),
+		},
+		{
+			name:     "gpt-image-1-mini prices its image output tokens",
+			pricing:  gptImage1Mini,
+			usage:    &core.ImageUsage{InputTokens: 9, OutputTokens: 272},
+			images:   1,
+			wantCost: new(9*2/1e6 + 272*8/1e6),
+		},
+		{
+			name:     "a response without usage is billed per image",
+			pricing:  dalle,
+			images:   2,
+			wantCost: new(0.08),
+		},
+		{
+			name:       "reported tokens with no rate are flagged, not silently free",
+			pricing:    &core.ModelPricing{InputPerMtok: new(2.0)},
+			usage:      &core.ImageUsage{InputTokens: 9, OutputTokens: 272},
+			images:     1,
+			wantCost:   new(9 * 2 / 1e6),
+			wantCaveat: caveatImageUnpricedOutput,
+		},
+		{
+			name:       "no usage and no per-image rate stays flagged",
+			pricing:    &core.ModelPricing{InputPerMtok: new(0.3), OutputPerMtok: new(30.0)},
+			images:     1,
+			wantCost:   new(0.0), // zero-token math, which is exactly why it is flagged
+			wantCaveat: caveatImageMissingUsage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &core.ImageGenerationResponse{Usage: tt.usage}
+			for range tt.images {
+				resp.Data = append(resp.Data, core.ImageData{B64JSON: "aGk="})
+			}
+
+			entry := ExtractFromImageResponse(resp, "req", "m", "openai", tt.pricing)
+
+			switch {
+			case tt.wantCost == nil && entry.TotalCost != nil:
+				t.Errorf("total cost = %v, want nil", *entry.TotalCost)
+			case tt.wantCost != nil && entry.TotalCost == nil:
+				t.Errorf("total cost = nil, want %v", *tt.wantCost)
+			case tt.wantCost != nil && !costsNearlyEqual(*entry.TotalCost, *tt.wantCost):
+				t.Errorf("total cost = %v, want %v", *entry.TotalCost, *tt.wantCost)
+			}
+			if entry.CostsCalculationCaveat != tt.wantCaveat {
+				t.Errorf("caveat = %q, want %q", entry.CostsCalculationCaveat, tt.wantCaveat)
+			}
+		})
 	}
 }
 

--- a/internal/usage/images_test.go
+++ b/internal/usage/images_test.go
@@ -221,6 +221,33 @@ func TestImageBillingUnit(t *testing.T) {
 	}
 }
 
+// TestImageCostCaveat_TimeWindowRate guards the caveat against disagreeing with
+// the cost: when a time window supplies the output rate, the row is priced and
+// must not also be flagged as unpriceable.
+func TestImageCostCaveat_TimeWindowRate(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok: new(5.0),
+		TimeWindows: []core.ModelPricingTimeWindow{{
+			Label:     "always",
+			UTCRanges: []core.ModelPricingUTCRange{{Start: "00:00", End: "00:00"}},
+			Pricing:   core.ModelPricingTimeWindowRates{OutputPerMtok: new(40.0)},
+		}},
+	}
+	resp := &core.ImageGenerationResponse{
+		Data:  []core.ImageData{{B64JSON: "aGk="}},
+		Usage: &core.ImageUsage{InputTokens: 9, OutputTokens: 272},
+	}
+
+	entry := ExtractFromImageResponse(resp, "req", "m", "openai", pricing)
+
+	if entry.TotalCost == nil || !costsNearlyEqual(*entry.TotalCost, 9*5/1e6+272*40/1e6) {
+		t.Errorf("total cost = %v, want the time-window rate applied", entry.TotalCost)
+	}
+	if entry.CostsCalculationCaveat != "" {
+		t.Errorf("caveat = %q, want none when the window priced the row", entry.CostsCalculationCaveat)
+	}
+}
+
 func TestExtractFromImageResponse_NoUsageCaveat(t *testing.T) {
 	// A token-priced model whose serving surface returns no usage block
 	// (e.g. Gemini's OpenAI-compatible images endpoint) must say why the

--- a/internal/usage/recalculate_pricing.go
+++ b/internal/usage/recalculate_pricing.go
@@ -78,7 +78,7 @@ func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) r
 	effectivePricing := pricingForEndpoint(pricing.AtTime(entry.Timestamp), entry.Endpoint)
 	result := CalculateUsageCost(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing)
 	caveat := result.Caveat
-	if retained := retainedMissingUsageCaveat(entry.Caveat, entry.RawData, effectivePricing); retained != "" {
+	if retained := retainedMissingUsageCaveat(entry.Caveat, entry.OutputTokens, entry.RawData, effectivePricing); retained != "" {
 		if caveat == "" {
 			caveat = retained
 		} else {

--- a/web/dashboard/messages/de.json
+++ b/web/dashboard/messages/de.json
@@ -1462,6 +1462,7 @@
   "models_price_batch_output": "Batch-Ausgabe $/MTok",
   "models_price_audio_input": "Audio-Eingabe $/MTok",
   "models_price_audio_output": "Audio-Ausgabe $/MTok",
+  "models_price_output_image_per_mtok": "Bildausgabe $/MTok",
   "models_price_per_image": "$/Bild",
   "models_price_input_image": "Eingabe $/Bild",
   "models_price_input_second": "Eingabe $/Sekunde",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -1462,6 +1462,7 @@
   "models_price_batch_output": "Batch output $/MTok",
   "models_price_audio_input": "Audio input $/MTok",
   "models_price_audio_output": "Audio output $/MTok",
+  "models_price_output_image_per_mtok": "Image output $/MTok",
   "models_price_per_image": "$/Image",
   "models_price_input_image": "Input $/Image",
   "models_price_input_second": "Input $/Second",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -1490,6 +1490,7 @@
   "models_price_batch_output": "Wyjście Batch $/MTok",
   "models_price_audio_input": "Wejście Audio $/MTok",
   "models_price_audio_output": "Wyjście Audio $/MTok",
+  "models_price_output_image_per_mtok": "Wyjście obrazu $/MTok",
   "models_price_per_image": "$/obraz",
   "models_price_input_image": "Wejście $/obraz",
   "models_price_input_second": "Wejście $/sekundę",

--- a/web/dashboard/messages/zh-CN.json
+++ b/web/dashboard/messages/zh-CN.json
@@ -1333,6 +1333,7 @@
   "models_price_batch_output": "批量输出 $/MTok",
   "models_price_audio_input": "音频输入 $/MTok",
   "models_price_audio_output": "音频输出 $/MTok",
+  "models_price_output_image_per_mtok": "图像输出 $/MTok",
   "models_price_per_image": "$/图像",
   "models_price_input_image": "输入 $/图像",
   "models_price_input_second": "输入 $/秒",

--- a/web/dashboard/src/pages/models/pricingOverridesLogic.js
+++ b/web/dashboard/src/pages/models/pricingOverridesLogic.js
@@ -12,6 +12,7 @@ export const PRICE_FIELDS = [
   { value: "batch_output_per_mtok", label: m.models_price_batch_output(), group: m.models_price_group_batch() },
   { value: "audio_input_per_mtok", label: m.models_price_audio_input(), group: m.models_price_group_audio() },
   { value: "audio_output_per_mtok", label: m.models_price_audio_output(), group: m.models_price_group_audio() },
+  { value: "output_image_per_mtok", label: m.models_price_output_image_per_mtok(), group: m.models_price_group_image() },
   { value: "per_image", label: m.models_price_per_image(), group: m.models_price_group_image() },
   { value: "input_per_image", label: m.models_price_input_image(), group: m.models_price_group_image() },
   { value: "per_second_input", label: m.models_price_input_second(), group: m.models_price_group_audio_video() },


### PR DESCRIPTION
Image and audio calls were metered by rules that double-charged, under-charged, or silently skipped the charge. One pricing rule now decides the billable unit: **a model is billed by the unit the provider reported, never by two at once.**

## Images

- Gemini image models were charged their output tokens **and** `per_image` — two spellings of the same charge (`gemini-2.5-flash-image`: $30/Mtok × 1290 tokens = $0.0387 = its `per_image` of $0.039). Every generation and edit was billed exactly 2×. `per_image` now applies only to responses that reported no generated tokens (DALL·E, Imagen, grok-imagine).
- `gpt-image-1` was billed a flat $0.167 per image regardless of size or quality (15× over for `quality: low`), and `gpt-image-1-mini` recorded ~0.4% of its real cost with no caveat. Both are now priced by their generated image tokens through a new `output_image_per_mtok` rate, which is what these providers actually charge — `gpt-image-1` has no text output rate at all, and Gemini 3 Pro Image bills image output at $120/Mtok against $12/Mtok for text.

Measured through the gateway against the providers' published prices:

| call | before | after | provider's price |
| --- | --- | --- | --- |
| `gemini-2.5-flash-image` generation (1290 out) | 0.0777015 | 0.0387015 | $30/Mtok |
| `gemini-2.5-flash-image` edit (1290 out) | 0.0777786 | 0.0387786 | $30/Mtok |
| `gpt-image-1` 1024², quality low (272 out) | 0.167045 | 0.010925 | $0.011 |
| `gpt-image-1` 1024², quality medium (1056 out) | 0.167045 | 0.042285 | $0.042 |
| `gpt-image-1-mini` 1024², quality low (272 out) | 0.000018 | 0.002194 | $8/Mtok |

## Audio

- The same transcription was billed or free depending on `response_format`: `json`/`verbose_json` carried a usage object, `text`/`srt`/`vtt` did not. Groq and ElevenLabs transcriptions and **all** translations were never billed. Duration now comes from `usage.seconds`, else `verbose_json`'s `duration`, else the uploaded audio measured by the gateway (wav/mp3, the same measurement already used for synthesized speech). A `whisper-1` call costs $0.000235 in every format (was $0.0003 / $0.0003 / $0 / $0 / $0); `groq/whisper-large-v3-turbo` and translations are metered instead of dropped.
- A model that reported tokens is priced by tokens and not additionally by duration (`whisper-1` publishes both rates for the same audio).

## Caveats

The cost caveat now means "we could not price this" rather than "the provider sent no usage": it fires for reported image tokens with no rate, and for a transcription with no reported usage whose upload is in a container the gateway cannot measure (m4a, ogg, flac, webm). Pricing recalculation keeps or lifts it accordingly.

## Docs

`docs/advanced/audio-api.mdx` claimed audio is "not recorded in usage tracking", which was never true — replaced with a Cost tracking section. Image and cost-tracking pages describe the one-unit rule.

## Notes

- Where a provider states a duration it stays authoritative, so OpenAI rounding `2.35s` up to `3s` on `json` still differs slightly from the measured `2.35s` on `text`/`srt`/`vtt`.
- `output_image_per_mtok` is settable as a pricing override (`config.yaml`, the admin pricing overrides API, and the dashboard's price editor).

## Testing

`go build ./...`, `go test -race ./...` (only the pre-existing dashboard-asset failures), `make lint`. New table-driven tests in `internal/usage` pin the image billing unit and the transcription duration sources. Verified live against OpenAI, Gemini, Groq and ElevenLabs with the calls in the tables above, comparing `/admin/usage/log` against published prices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added image-output token pricing for model catalogs and pricing overrides.
  - Audio transcription and translation costs can now be calculated from measured audio duration when provider usage data is unavailable.
  - Audit logs now include per-request guardrail outcomes.

- **Bug Fixes**
  - Image requests reporting generated tokens are billed by tokens rather than combined with per-image rates.
  - Added clearer cost-calculation caveats when usage or pricing data is insufficient.

- **Documentation**
  - Updated audio, image, and cost-tracking guides with supported billing units and pricing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
