### PR TITLE
fix(cache): scope exact response-cache entries to the guardrail chain

### DIFF
--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -693,6 +693,30 @@ path (the native passthrough is skipped). A response cut by a guardrail is
 reported with `finish_reason: "content_filter"` on OpenAI-compatible
 endpoints and `stop_reason: "end_turn"` on `/v1/messages`.
 
+## Guardrails and the Response Cache
+
+The [response cache](/features/cache) stores the reply the response and stream
+chains already produced, and a cache hit replays it without running those
+chains again. Both cache layers therefore key on the guardrail chain the
+request resolves to, across all three phases:
+
+- Editing, adding or removing a step makes every entry stored under the old
+  chain unreachable; the next request runs the full pipeline and stores its own
+  entry.
+- Two workflows with different chains never share entries, so a tenant whose
+  workflow redacts on the way out is never served another tenant's unredacted
+  reply.
+- A blocked response is not a cacheable response, so a blocking guardrail can
+  never be skipped by a hit.
+
+Prompt-phase guardrails run before the cache is consulted, so a prompt-phase
+block or answer applies to a request that would otherwise have been a hit. A
+response a guardrail restores request-specific data into is never cached at all
+(see `restore` under [`presidio`](#presidio)).
+
+Because the response chain does not run on a hit, the audit entry for a hit
+records the prompt-phase outcomes only, plus the cache type.
+
 ## Decisions, Errors, and Rejection
 
 | Outcome | What the client sees |

--- a/docs/advanced/workflows.mdx
+++ b/docs/advanced/workflows.mdx
@@ -99,8 +99,9 @@ workflows are returned unchanged; the dashboard always writes version 2.
 
 Workflow views (`GET /admin/workflows`, `GET /admin/workflows/:id`) expose the
 hash of each compiled chain as `chain_hashes` (`{"prompt": "...", "response": "...", "stream": "..."}`).
-The prompt hash is part of the semantic response cache key, so changing a
-prompt-phase guardrail invalidates cached answers produced under the old rules.
+The compiled chain identity is part of both response cache keys, so changing a
+guardrail in any phase invalidates cached answers produced under the old rules,
+and two workflows with different chains never share cached answers.
 
 ## Examples
 

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -94,10 +94,19 @@ The exact cache hashes:
 - the request path
 - the resolved workflow context used for execution
   specifically execution mode, provider type, and resolved model
+- the guardrail chain the request resolves to, across the prompt, response and
+  stream phases
 - the final request body
 
 This means guardrails and workflows affect cache keys when they change the
 resolved workflow or the final body sent through execution.
+
+A cache hit replays the stored response without re-running the response and
+stream guardrail chains, so an entry is only ever served to a request whose
+chain matches the one that produced it. Editing, adding or removing a guardrail
+step — or a second workflow with a different chain — yields a miss instead of a
+reply those guardrails never saw. Changing guardrail configuration therefore
+invalidates the entries stored under the old chain.
 
 JSON object member order and insignificant whitespace are canonicalized before
 hashing. Requests that differ only in formatting therefore share one exact

--- a/internal/responsecache/exact_cache_test.go
+++ b/internal/responsecache/exact_cache_test.go
@@ -372,7 +372,7 @@ func TestStoreAfter_CacheableFollowerStoresAfterNonCacheableLeader(t *testing.T)
 		t.Fatalf("follower error: %v", err)
 	}
 	m.wg.Wait()
-	key := hashRequest("/v1/chat/completions", body, nil)
+	key := hashRequest("/v1/chat/completions", body, nil, "")
 	if cached, err := store.Get(context.Background(), key); err != nil || len(cached) == 0 {
 		t.Fatalf("cached follower response = %q, err=%v", cached, err)
 	}
@@ -426,8 +426,8 @@ func TestHashRequest_CanonicalizesJSONFormattingAndKeyOrder(t *testing.T) {
 		{name: "oversized number before duplicate names", first: `{"n":1e1000000,"model":"a","model":"b"}`, second: `{"n":1e1000000,"model":"b"}`, equal: false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			first := hashRequest("/v1/embeddings", []byte(tt.first), plan)
-			second := hashRequest("/v1/embeddings", []byte(tt.second), plan)
+			first := hashRequest("/v1/embeddings", []byte(tt.first), plan, "")
+			second := hashRequest("/v1/embeddings", []byte(tt.second), plan, "")
 			if got := first == second; got != tt.equal {
 				t.Fatalf("key equality = %v, want %v: %s / %s", got, tt.equal, first, second)
 			}
@@ -446,8 +446,8 @@ func TestHashRequest_DuplicateNamesDoNotCollideAfterTypedDecoding(t *testing.T) 
 		{path: "/v1/responses", duplicate: `{"model":"a","model":"b","input":[]}`, collapsed: `{"model":"b","input":[]}`},
 	} {
 		t.Run(tt.path, func(t *testing.T) {
-			first := hashRequest(tt.path, []byte(tt.duplicate), plan)
-			second := hashRequest(tt.path, []byte(tt.collapsed), plan)
+			first := hashRequest(tt.path, []byte(tt.duplicate), plan, "")
+			second := hashRequest(tt.path, []byte(tt.collapsed), plan, "")
 			if first == second {
 				t.Fatal("duplicate-member request collided with its collapsed form")
 			}
@@ -463,13 +463,13 @@ func TestHashRequest_ResolvedModelChangesKey(t *testing.T) {
 		Resolution: &core.RequestModelResolution{
 			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"},
 		},
-	})
+	}, "")
 	second := hashRequest("/v1/chat/completions", body, &core.Workflow{
 		Mode: core.ExecutionModeTranslated,
 		Resolution: &core.RequestModelResolution{
 			ResolvedSelector: core.ModelSelector{Provider: "anthropic", Model: "claude-opus-4-6"},
 		},
-	})
+	}, "")
 
 	if first == second {
 		t.Fatal("resolved model should affect cache key")
@@ -481,10 +481,10 @@ func TestHashRequest_ModeChangesKey(t *testing.T) {
 
 	first := hashRequest("/v1/chat/completions", body, &core.Workflow{
 		Mode: core.ExecutionModeTranslated,
-	})
+	}, "")
 	second := hashRequest("/v1/chat/completions", body, &core.Workflow{
 		Mode: core.ExecutionModePassthrough,
-	})
+	}, "")
 
 	if first == second {
 		t.Fatal("execution mode should affect cache key")
@@ -502,8 +502,8 @@ func TestHashRequest_StreamIncludeUsageChangesKey(t *testing.T) {
 		},
 	}
 
-	first := hashRequest("/v1/chat/completions", base, plan)
-	second := hashRequest("/v1/chat/completions", withUsage, plan)
+	first := hashRequest("/v1/chat/completions", base, plan, "")
+	second := hashRequest("/v1/chat/completions", withUsage, plan, "")
 
 	if first == second {
 		t.Fatal("stream_options.include_usage should affect the exact cache key")
@@ -521,8 +521,8 @@ func TestHashRequest_StreamModeChangesKey(t *testing.T) {
 		},
 	}
 
-	first := hashRequest("/v1/chat/completions", base, plan)
-	second := hashRequest("/v1/chat/completions", streaming, plan)
+	first := hashRequest("/v1/chat/completions", base, plan, "")
+	second := hashRequest("/v1/chat/completions", streaming, plan, "")
 
 	if first == second {
 		t.Fatal("stream mode should affect the exact cache key")
@@ -605,6 +605,167 @@ func TestHandleRequest_SeparatesStreamingAndNonStreamingEntries(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Fatalf("non-streaming exact hit should not call handler again, got %d calls", callCount)
+	}
+}
+
+// driveChainedRequest drives HandleRequest with a guardrail chain identity on
+// the request context, the way the inference orchestrator does for a request
+// whose workflow declares guardrail steps.
+func driveChainedRequest(
+	t *testing.T,
+	mw *ResponseCacheMiddleware,
+	workflow *core.Workflow,
+	chainHash string,
+	body []byte,
+	next func(c *echo.Context) error,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := req.Context()
+	if workflow != nil {
+		ctx = core.WithWorkflow(ctx, workflow)
+	}
+	req = req.WithContext(core.WithGuardrailsHash(ctx, chainHash))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := mw.HandleRequest(c, body, func() error { return next(c) }); err != nil {
+		t.Fatalf("HandleRequest: %v", err)
+	}
+	return rec
+}
+
+func TestHashRequest_GuardrailChainChangesKey(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	plan := resolvedWorkflow("openai", "gpt-4")
+
+	none := hashRequest("/v1/chat/completions", body, plan, "")
+	chainA := hashRequest("/v1/chat/completions", body, plan, "chain-a")
+	chainB := hashRequest("/v1/chat/completions", body, plan, "chain-b")
+
+	if none == chainA || chainA == chainB {
+		t.Fatalf("guardrail chain identity must change the exact cache key: %s / %s / %s", none, chainA, chainB)
+	}
+	if chainA != hashRequest("/v1/chat/completions", body, plan, "chain-a") {
+		t.Fatal("exact cache key must be stable for the same chain")
+	}
+}
+
+// A body cached under one guardrail chain must never be replayed to a request
+// whose response/stream chain differs: the replay skips the response phase, so
+// the entry is only valid for the chain that produced it.
+func TestHandleRequest_ExactCacheIsScopedToGuardrailChain(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	workflow := resolvedWorkflow("openai", "gpt-4")
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+
+	calls := 0
+	next := func(c *echo.Context) error {
+		calls++
+		return c.JSON(http.StatusOK, map[string]string{"result": "unguarded"})
+	}
+
+	if got := driveChainedRequest(t, mw, workflow, "", body, next).Header().Get("X-Cache"); got != "" {
+		t.Fatalf("first request should miss, got X-Cache=%q", got)
+	}
+	mw.simple.wg.Wait()
+
+	// Same request, same (empty) chain: still a hit.
+	if got := driveChainedRequest(t, mw, workflow, "", body, next).Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("unchanged chain should still hit, got X-Cache=%q", got)
+	}
+	if calls != 1 {
+		t.Fatalf("hit should not call the provider again, calls=%d", calls)
+	}
+
+	// A workflow that adds a response-phase guardrail must miss instead of
+	// receiving the body stored before the guardrail existed.
+	guarded := driveChainedRequest(t, mw, workflow, "response-redaction-chain", body, func(c *echo.Context) error {
+		calls++
+		return c.JSON(http.StatusOK, map[string]string{"result": "guarded"})
+	})
+	if got := guarded.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("changed guardrail chain must miss, got X-Cache=%q", got)
+	}
+	if !bytes.Contains(guarded.Body.Bytes(), []byte("guarded")) {
+		t.Fatalf("changed chain served a stale body: %s", guarded.Body.String())
+	}
+	if calls != 2 {
+		t.Fatalf("changed chain should run the full pipeline, calls=%d", calls)
+	}
+	mw.simple.wg.Wait()
+
+	// The guarded entry is its own entry and replays only to its own chain.
+	if got := driveChainedRequest(t, mw, workflow, "response-redaction-chain", body, next).Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("second request on the guarded chain should hit, got X-Cache=%q", got)
+	}
+	if calls != 2 {
+		t.Fatalf("guarded hit should not call the provider again, calls=%d", calls)
+	}
+}
+
+// Two tenants sharing one cache but resolving different workflows must not
+// share entries when their guardrail chains differ, with no config change.
+func TestHandleRequest_ExactCacheIsolatesTenantsWithDifferentChains(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	workflow := resolvedWorkflow("openai", "gpt-4")
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"tenant-xtalk"}]}`)
+
+	unguarded := driveChainedRequest(t, mw, workflow, "", body, func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"result": "ECHO"})
+	})
+	if got := unguarded.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("priming request should miss, got X-Cache=%q", got)
+	}
+	mw.simple.wg.Wait()
+
+	rec := driveChainedRequest(t, mw, workflow, "tenant-b-chain", body, func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"result": "GUARDED"})
+	})
+	if got := rec.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("a tenant with its own guardrail chain must not read another tenant's entry, got X-Cache=%q", got)
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("GUARDED")) {
+		t.Fatalf("tenant with a response guardrail received an unguarded body: %s", rec.Body.String())
+	}
+}
+
+// A streaming reply cached under one stream chain must not replay to a request
+// whose stream guardrails differ; the SSE replay runs no stream phase.
+func TestHandleRequest_StreamReplayIsScopedToGuardrailChain(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	workflow := resolvedWorkflow("openai", "gpt-4")
+	body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	rawStream := []byte(
+		"data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"sk-secret\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+			"data: [DONE]\n\n",
+	)
+	streamNext := func(c *echo.Context) error {
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().WriteHeader(http.StatusOK)
+		_, err := c.Response().Write(rawStream)
+		return err
+	}
+
+	if got := driveChainedRequest(t, mw, workflow, "", body, streamNext).Header().Get("X-Cache"); got != "" {
+		t.Fatalf("first streaming request should miss, got X-Cache=%q", got)
+	}
+	mw.simple.wg.Wait()
+
+	if got := driveChainedRequest(t, mw, workflow, "", body, streamNext).Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("same stream chain should replay, got X-Cache=%q", got)
+	}
+
+	if got := driveChainedRequest(t, mw, workflow, "stream-mask-chain", body, streamNext).Header().Get("X-Cache"); got != "" {
+		t.Fatalf("a new stream-phase guardrail must invalidate the cached replay, got X-Cache=%q", got)
 	}
 }
 

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -75,8 +75,7 @@ func (m *simpleCacheMiddleware) TryHit(ex exchange, body []byte) (bool, error) {
 		return false, nil
 	}
 	path := ex.Path()
-	plan := core.GetWorkflow(ex.Context())
-	key := hashRequest(path, body, plan)
+	key := exactCacheKey(ex, body)
 	cached, err := m.store.Get(ex.Context(), key)
 	if err != nil {
 		return false, nil
@@ -106,9 +105,7 @@ func (m *simpleCacheMiddleware) StoreAfter(ex exchange, body []byte, next func()
 	if m == nil || m.store == nil {
 		return next()
 	}
-	path := ex.Path()
-	plan := core.GetWorkflow(ex.Context())
-	key := hashRequest(path, body, plan)
+	key := exactCacheKey(ex, body)
 
 	call, leader := m.joinMiss(key)
 	if leader {
@@ -140,6 +137,13 @@ func (m *simpleCacheMiddleware) StoreAfter(ex exchange, body []byte, next func()
 		m.hitRecorder(ex, call.data, CacheTypeExact)
 	}
 	return err
+}
+
+// exactCacheKey derives the exact-cache key for one exchange, scoping the entry
+// to the request's guardrail chain identity.
+func exactCacheKey(ex exchange, body []byte) string {
+	ctx := ex.Context()
+	return hashRequest(ex.Path(), body, core.GetWorkflow(ctx), core.GetGuardrailsHash(ctx))
 }
 
 // captureAndStore executes one cache miss without joining the coalescing
@@ -259,7 +263,13 @@ func isStreamingRequestGJSON(path string, body []byte) bool {
 	return result.Bool()
 }
 
-func hashRequest(path string, body []byte, plan *core.Workflow) string {
+// hashRequest builds the exact-cache key. chainHash is the effective guardrail
+// chain identity (prompt, response and stream phases; see plugins.Chains.CacheHash),
+// already computed once per request by the workflow compiler and carried on the
+// context. Mixing it in scopes every entry to the chain that produced it, so a
+// request whose response or stream guardrails differ misses instead of being
+// served a body those guardrails never saw.
+func hashRequest(path string, body []byte, plan *core.Workflow, chainHash string) string {
 	h := sha256.New()
 	h.Write([]byte(path))
 	h.Write([]byte{0})
@@ -271,6 +281,8 @@ func hashRequest(path string, body []byte, plan *core.Workflow) string {
 		h.Write([]byte(plan.ResolvedQualifiedModel()))
 		h.Write([]byte{0})
 	}
+	h.Write([]byte(chainHash))
+	h.Write([]byte{0})
 	h.Write(cacheKeyRequestBody(path, body))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -7365,3 +7365,141 @@ func TestHandleWithCache_ClassifiesStalledClientOnCachedStream(t *testing.T) {
 		t.Fatalf("cache_type = %q, want %q", entry.CacheType, auditlog.CacheTypeExact)
 	}
 }
+
+// guardrailChainWorkflow builds a resolved workflow whose policy carries the
+// given guardrail chain identity (plugins.Chains.CacheHash).
+func guardrailChainWorkflow(chainHash string) *core.Workflow {
+	return &core.Workflow{
+		Mode:         core.ExecutionModeTranslated,
+		ProviderType: "openai",
+		Resolution: &core.RequestModelResolution{
+			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4o-mini"},
+		},
+		Policy: &core.ResolvedWorkflowPolicy{
+			VersionID:      "v-" + chainHash,
+			Features:       core.DefaultWorkflowFeatures(),
+			GuardrailsHash: chainHash,
+		},
+	}
+}
+
+// driveCachedChatRequest runs handleWithCache the way the translated service
+// does, with the workflow's guardrail chain identity on the request context.
+func driveCachedChatRequest(
+	t *testing.T,
+	s *translatedInferenceService,
+	orchestrator *gateway.InferenceOrchestrator,
+	workflow *core.Workflow,
+	req *core.ChatRequest,
+	body []byte,
+	dispatch func(*echo.Context, *core.ChatRequest, *core.Workflow) error,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r = r.WithContext(orchestrator.WithCacheRequestContext(r.Context(), workflow))
+	c := e.NewContext(r, rec)
+	if err := handleWithCache(s, c, req, workflow, dispatch); err != nil {
+		t.Fatalf("handleWithCache: %v", err)
+	}
+	return rec
+}
+
+// TestHandleWithCache_ExactEntryIsScopedToGuardrailChain covers the policy
+// bypass where a cached body produced without a response guardrail was replayed
+// to a request whose workflow declares one. Cache hits skip dispatch, where the
+// response and stream chains run, so an entry may only serve a matching chain.
+func TestHandleWithCache_ExactEntryIsScopedToGuardrailChain(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	s := &translatedInferenceService{responseCache: mw}
+	orchestrator := gateway.NewInferenceOrchestrator(gateway.InferenceConfig{})
+
+	req := &core.ChatRequest{Model: "gpt-4o-mini", Messages: []core.Message{{Role: "user", Content: "give me the key"}}}
+	body, err := marshalRequestBody(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	unguarded := guardrailChainWorkflow("")
+	redacting := guardrailChainWorkflow("response-redaction-chain")
+
+	dispatches := 0
+	raw := func(c *echo.Context, _ *core.ChatRequest, _ *core.Workflow) error {
+		dispatches++
+		return c.JSON(http.StatusOK, map[string]string{"answer": "sk-ABCDEFGHIJKLMNOPQRSTUVWX1234"})
+	}
+
+	if got := driveCachedChatRequest(t, s, orchestrator, unguarded, req, body, raw).Header().Get("X-Cache"); got != "" {
+		t.Fatalf("priming request X-Cache = %q, want a miss", got)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("wait for cache write: %v", err)
+	}
+
+	// Same chain: still a hit, and dispatch is skipped.
+	hit := driveCachedChatRequest(t, s, orchestrator, unguarded, req, body, raw)
+	if got := hit.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("unchanged chain X-Cache = %q, want HIT (exact)", got)
+	}
+	if dispatches != 1 {
+		t.Fatalf("dispatches after the hit = %d, want 1", dispatches)
+	}
+
+	// A workflow with a response-phase redaction step must not be served the
+	// body stored under the unguarded chain.
+	guarded := driveCachedChatRequest(t, s, orchestrator, redacting, req, body, func(c *echo.Context, _ *core.ChatRequest, _ *core.Workflow) error {
+		dispatches++
+		return c.JSON(http.StatusOK, map[string]string{"answer": "[redacted]"})
+	})
+	if got := guarded.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("changed chain X-Cache = %q, want a miss", got)
+	}
+	if dispatches != 2 {
+		t.Fatalf("changed chain must run dispatch, dispatches = %d", dispatches)
+	}
+	if strings.Contains(guarded.Body.String(), "sk-ABCDEFGHIJKLMNOPQRSTUVWX1234") {
+		t.Fatalf("response guardrail was bypassed by the cache: %s", guarded.Body.String())
+	}
+}
+
+// TestHandleWithCache_BlockedResponseIsNotServedFromCache covers a response
+// guardrail that blocks: the blocked response is never stored, so a repeat
+// request runs the chain again instead of replaying a would-be hit.
+func TestHandleWithCache_BlockedResponseIsNotServedFromCache(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	defer mw.Close()
+	s := &translatedInferenceService{responseCache: mw}
+	orchestrator := gateway.NewInferenceOrchestrator(gateway.InferenceConfig{})
+
+	req := &core.ChatRequest{Model: "gpt-4o-mini", Messages: []core.Message{{Role: "user", Content: "blocked"}}}
+	body, err := marshalRequestBody(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	workflow := guardrailChainWorkflow("response-block-chain")
+
+	dispatches := 0
+	blocking := func(c *echo.Context, _ *core.ChatRequest, _ *core.Workflow) error {
+		dispatches++
+		return c.JSON(http.StatusUnavailableForLegalReasons, map[string]string{"error": "blocked by guardrail"})
+	}
+
+	for i := range 2 {
+		rec := driveCachedChatRequest(t, s, orchestrator, workflow, req, body, blocking)
+		if got := rec.Header().Get("X-Cache"); got != "" {
+			t.Fatalf("request %d X-Cache = %q, want no cache hit for a blocked response", i+1, got)
+		}
+		if rec.Code != http.StatusUnavailableForLegalReasons {
+			t.Fatalf("request %d status = %d, want the guardrail block status", i+1, rec.Code)
+		}
+	}
+	if dispatches != 2 {
+		t.Fatalf("dispatches = %d, want the blocking chain to run on every request", dispatches)
+	}
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -7383,6 +7383,35 @@ func guardrailChainWorkflow(chainHash string) *core.Workflow {
 	}
 }
 
+// cacheWriteSignalStore reports each completed cache write so a test can wait
+// for the asynchronous store without shutting the middleware down.
+type cacheWriteSignalStore struct {
+	cache.Store
+	writes chan struct{}
+}
+
+func newCacheWriteSignalStore() *cacheWriteSignalStore {
+	return &cacheWriteSignalStore{Store: cache.NewMapStore(), writes: make(chan struct{}, 16)}
+}
+
+func (s *cacheWriteSignalStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	err := s.Store.Set(ctx, key, value, ttl)
+	select {
+	case s.writes <- struct{}{}:
+	default:
+	}
+	return err
+}
+
+func (s *cacheWriteSignalStore) waitForWrite(t *testing.T) {
+	t.Helper()
+	select {
+	case <-s.writes:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the response cache write")
+	}
+}
+
 // driveCachedChatRequest runs handleWithCache the way the translated service
 // does, with the workflow's guardrail chain identity on the request context.
 func driveCachedChatRequest(
@@ -7412,9 +7441,9 @@ func driveCachedChatRequest(
 // to a request whose workflow declares one. Cache hits skip dispatch, where the
 // response and stream chains run, so an entry may only serve a matching chain.
 func TestHandleWithCache_ExactEntryIsScopedToGuardrailChain(t *testing.T) {
-	store := cache.NewMapStore()
-	defer store.Close()
+	store := newCacheWriteSignalStore()
 	mw := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	defer mw.Close()
 	s := &translatedInferenceService{responseCache: mw}
 	orchestrator := gateway.NewInferenceOrchestrator(gateway.InferenceConfig{})
 
@@ -7436,9 +7465,7 @@ func TestHandleWithCache_ExactEntryIsScopedToGuardrailChain(t *testing.T) {
 	if got := driveCachedChatRequest(t, s, orchestrator, unguarded, req, body, raw).Header().Get("X-Cache"); got != "" {
 		t.Fatalf("priming request X-Cache = %q, want a miss", got)
 	}
-	if err := mw.Close(); err != nil {
-		t.Fatalf("wait for cache write: %v", err)
-	}
+	store.waitForWrite(t)
 
 	// Same chain: still a hit, and dispatch is skipped.
 	hit := driveCachedChatRequest(t, s, orchestrator, unguarded, req, body, raw)
@@ -7463,6 +7490,19 @@ func TestHandleWithCache_ExactEntryIsScopedToGuardrailChain(t *testing.T) {
 	}
 	if strings.Contains(guarded.Body.String(), "sk-ABCDEFGHIJKLMNOPQRSTUVWX1234") {
 		t.Fatalf("response guardrail was bypassed by the cache: %s", guarded.Body.String())
+	}
+
+	// The guarded miss stores its own entry, which replays only to its chain.
+	store.waitForWrite(t)
+	replay := driveCachedChatRequest(t, s, orchestrator, redacting, req, body, raw)
+	if got := replay.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("second request on the guarded chain X-Cache = %q, want HIT (exact)", got)
+	}
+	if !strings.Contains(replay.Body.String(), "[redacted]") {
+		t.Fatalf("guarded chain replayed %s, want the guarded body", replay.Body.String())
+	}
+	if dispatches != 2 {
+		t.Fatalf("guarded hit should not dispatch again, dispatches = %d", dispatches)
 	}
 }
 


### PR DESCRIPTION
A response-cache hit replays the stored body without running the response and stream guardrail chains, but the exact cache key ignored the chain (the semantic layer already mixes it in). Two consequences:

- A body cached while a workflow had no response/stream step was replayed verbatim after such a step was added — an unredacted `sk-…` served on `X-Cache: HIT (exact)`.
- With no configuration change at all, a key whose workflow has no response guardrail could prime an entry that a key whose workflow redacts on the way out then received unguarded.

Fix: the exact cache key now mixes in the effective guardrail chain identity (`plugins.Chains.CacheHash`, covering the prompt, response and stream phases), which the workflow compiler already computes once per version and the orchestrator already puts on the request context. An entry can therefore only be served to a request whose chain matches the one that produced it; the response phase still does not re-run on a hit, because the cached body was produced by the same chain. Changing guardrail configuration invalidates entries stored under the old chain.

User-visible impact: same chain still hits; editing, adding or removing a guardrail step, or a second workflow with a different chain, now misses instead of replaying a body those guardrails never saw. A blocked response is not cacheable, so a blocking response guardrail can never be skipped by a hit. Prompt-phase behaviour and the presidio `restore` no-store rule are unchanged. Docs updated in `docs/features/cache.mdx`, `docs/advanced/guardrails.mdx` and `docs/advanced/workflows.mdx`.

Tested: new table/unit tests in `internal/responsecache` (chain changes the key; entries scoped per chain; cross-tenant isolation; stream replay) and `internal/server` (hit skips dispatch only for a matching chain; a blocked response is never cached), all failing before the change. Live-verified against a gateway with the Redis exact cache, a mock upstream and real workflows: both original repros, same chain → hit, changed chain → miss, a blocking response guardrail over a would-be hit, and a stream-phase guardrail on a cached SSE replay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that response cache entries are scoped to the complete guardrail chain across prompt, response, and stream phases.
  * Documented that changing guardrails invalidates existing cached responses and prevents workflows with different chains from sharing entries.
  * Explained that blocked responses and responses restored with request-specific data are not cached.
  * Clarified cache-hit behavior, including which guardrail phases run and what audit information is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->