### PR TITLE
fix(guardrails): enforce admission around prompt guardrails and refuse unguarded passthrough

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -86,6 +86,12 @@
 # Cohere native passthrough is opt-in; add cohere when those routes are needed.
 # ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,cohere,openrouter,kilo,zai,sglang,vllm,llamacpp,llmd,deepseek,hetzner
 
+# Serve /p/{provider}/... to callers a guardrail workflow applies to (default: false).
+# Passthrough forwards provider-native bodies untouched, so no guardrail chain runs on
+# them; by default such a request is refused with 403 instead of silently escaping the
+# policy. Set to true only when passthrough traffic is trusted.
+# ALLOW_UNGUARDED_PASSTHROUGH=false
+
 # Enable the realtime (speech-to-speech) endpoints (default: true): the /v1/realtime
 # websocket (and /p/{provider}/v1/realtime passthrough upgrade), the WebRTC SDP
 # exchange at POST /v1/realtime/calls, and ephemeral browser credentials at

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -13,6 +13,7 @@ server:
   pprof_enabled: false # expose /debug/pprof/* for local profiling only
   enable_passthrough_routes: true # expose /p/{provider}/{endpoint} passthrough routes
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
+  allow_unguarded_passthrough: false # env: ALLOW_UNGUARDED_PASSTHROUGH; passthrough runs no guardrails, so by default a /p/... request is refused (403) when a guardrail workflow applies to the caller. true accepts the gap
   user_path_header: "X-GoModel-User-Path" # env: USER_PATH_HEADER; inbound header used for user_path scoping
   enabled_passthrough_providers: ["openai", "anthropic", "cohere", "openrouter", "kilo", "zai", "sglang", "vllm", "llmd", "deepseek", "bailian"] # providers enabled on /p/{provider}/...
   auth_verify_enabled: false # env: AUTH_VERIFY_ENABLED; expose GET /v1/auth/verify, which reports whether the API key a request carries authenticates against this gateway (401 when it does not; 200 with {"valid":false,"method":"none"} when the gateway has no authentication configured). Outside /admin, so it works with the admin API disabled

--- a/config/server.go
+++ b/config/server.go
@@ -37,6 +37,13 @@ type ServerConfig struct {
 	// UserPathHeader is the inbound HTTP header used to read/write user paths.
 	// Default: X-GoModel-User-Path.
 	UserPathHeader string `yaml:"user_path_header" env:"USER_PATH_HEADER"`
+	// AllowUnguardedPassthrough lets /p/{provider}/... serve callers a guardrail
+	// workflow applies to. Passthrough forwards provider-native bodies
+	// untouched, so no guardrail chain runs on them; by default such a request
+	// is refused (403) instead of silently escaping the policy. Default: false.
+	// Turn it on only when passthrough traffic is trusted, or scope the
+	// guardrail workflow so it does not match those callers.
+	AllowUnguardedPassthrough bool `yaml:"allow_unguarded_passthrough" env:"ALLOW_UNGUARDED_PASSTHROUGH"`
 	// EnabledPassthroughProviders lists the provider types enabled on
 	// /p/{provider}/... passthrough routes. Default:
 	// ["openai", "anthropic", "openrouter", "kilo", "zai", "sglang", "vllm", "llmd", "deepseek"].

--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -38,6 +38,19 @@ Guardrails work across all text-based endpoints:
   system and are not covered here.
 </Note>
 
+<Warning>
+  Guardrails do **not** run on the provider-native passthrough routes
+  (`/p/{provider}/...`). Those forward the caller's provider-native body and
+  relay the provider's answer untouched, so no chain can read or edit them. By
+  default GoModel therefore refuses a passthrough request whenever a guardrail
+  workflow applies to the caller, with `403 passthrough_guardrails_unsupported`
+  — the policy is never silently dropped. Set
+  `server.allow_unguarded_passthrough: true`
+  (`ALLOW_UNGUARDED_PASSTHROUGH=true`) to accept the gap, or scope the workflow
+  so it does not match those callers. See
+  [Passthrough API](/features/passthrough-api).
+</Warning>
+
 ## Quick Start
 
 Add a `guardrails` section to your `config/config.yaml`:
@@ -138,6 +151,27 @@ one editor per order, and any number of non-editing checks (`llm_judge`,
 `header_edit`) next to it. When several guardrails at one order decide
 differently, the most severe decision wins: `block` > `respond` > `warn` >
 `allow`.
+
+## Guardrails, rate limits, and budgets
+
+A prompt-phase guardrail can end the request itself (`block`) or answer it
+(`respond`), and an `llm_judge` step spends real provider money
+deciding that. So on a request that runs a prompt chain, rate limits and
+budgets are enforced **before** the chain:
+
+- A request over its rate limit or budget is refused with `429` without the
+  chain running, so a judge call is never made for a request the gateway will
+  not serve.
+- A request the chain blocks or answers still consumes its rate-limit token and
+  still had to pass the budget check — the decision is not a free request.
+- Because enforcement moves ahead of the cache lookup for these requests, a
+  response-cache hit on a request that runs a prompt chain counts too. Without
+  a prompt chain, cache hits stay free (see
+  [Rate limits](/features/rate-limits) and [Budgets](/features/budgets)).
+
+The judge's own inference is logged as its own usage entry under
+`<user_path>/guardrails/<instance>`, so its cost is attributed to the caller
+that triggered it.
 
 ## Configuration
 

--- a/docs/features/budgets.mdx
+++ b/docs/features/budgets.mdx
@@ -231,7 +231,11 @@ precedence.
 
 <Note>
   Response cache hits can return before budget enforcement. If a cached response
-  exists, GoModel can serve it without spending additional provider cost.
+  exists, GoModel can serve it without spending additional provider cost. A
+  request that runs a prompt-phase [guardrail](/advanced/guardrails) is the
+  exception: the chain can spend provider money (`llm_judge`) and can answer the
+  request itself, so the budget is checked before it runs, and a cache hit on
+  such a request is checked too.
 </Note>
 
 ## Reset windows

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -74,6 +74,44 @@ are recorded: token counts are read from SSE usage events on streaming
 responses and from the `usage` member of JSON responses, so costs and budgets
 account for passthrough traffic like any other route.
 
+## Guardrails do not run on passthrough
+
+Passthrough forwards the caller's provider-native body and relays the
+provider's answer untouched, so no [guardrail](/advanced/guardrails) chain can
+read or edit either one. Rate limits, budgets, model access, and usage
+accounting still apply; guardrails do not.
+
+To keep that from silently dropping a policy, GoModel refuses a passthrough
+request whenever a guardrail workflow applies to the caller:
+
+```json
+{
+  "error": {
+    "type": "permission_error",
+    "code": "passthrough_guardrails_unsupported",
+    "message": "provider passthrough cannot run guardrails, and a guardrail workflow applies to this request; ..."
+  }
+}
+```
+
+The request is answered with `403`. Route that traffic through the
+OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/responses`,
+`/v1/messages`), which do run the chains, or choose one of:
+
+```env
+# Accept unguarded passthrough for every caller (default: false)
+ALLOW_UNGUARDED_PASSTHROUGH=true
+```
+
+```yaml
+server:
+  allow_unguarded_passthrough: true
+```
+
+Alternatively, scope the guardrail [workflow](/advanced/workflows) so it does
+not match the callers that use passthrough. With no guardrail workflow
+matching a request, passthrough serves it as before.
+
 ## Anthropic SDK example
 
 Set the Anthropic SDK base URL to GoModel's Anthropic passthrough route. Use the
@@ -142,7 +180,8 @@ Passthrough is intentionally narrow while the API is in beta.
   passthrough can forward provider-native routes that do not identify a model.
   Add `chutes` to `ENABLED_PASSTHROUGH_PROVIDERS` only when you intend to expose
   that surface.
-- GoModel does not translate passthrough request bodies or response bodies.
+- GoModel does not translate passthrough request bodies or response bodies, so
+  guardrails cannot run on them (see above).
 - Provider-native error bodies and status codes are proxied instead of converted
   into OpenAI-compatible responses.
 - Features that depend on OpenAI-compatible request or response shapes may not
@@ -156,6 +195,7 @@ Passthrough routes are enabled by default:
 ENABLE_PASSTHROUGH_ROUTES=true
 ALLOW_PASSTHROUGH_V1_ALIAS=true
 ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,kilo,zai,sglang,vllm,llamacpp,llmd,deepseek
+ALLOW_UNGUARDED_PASSTHROUGH=false
 ```
 
 Set `ENABLED_PASSTHROUGH_PROVIDERS` to the provider types you want to expose.

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -99,6 +99,12 @@ model read from the provider-native body, and that read is best effort, so an
 inference call whose model GoModel cannot read is refused whenever *any*
 guardrail is configured — an unreadable body must not be a way around a policy.
 
+Only text-generating routes are refused: chat completions, responses, Anthropic
+messages, the legacy completion endpoints, and any provider-native path of the
+same shape. Model lists, token counts, embeddings, files, batches, images, and
+audio run no guardrail chain on `/v1` either, so passthrough serves them
+unchanged.
+
 Route that traffic through the
 OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/responses`,
 `/v1/messages`), which do run the chains, or choose one of:
@@ -199,7 +205,7 @@ Passthrough routes are enabled by default:
 ```env
 ENABLE_PASSTHROUGH_ROUTES=true
 ALLOW_PASSTHROUGH_V1_ALIAS=true
-ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,kilo,zai,sglang,vllm,llamacpp,llmd,deepseek
+ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,kilo,zai,sglang,vllm,llamacpp,llmd,deepseek,hetzner
 ALLOW_UNGUARDED_PASSTHROUGH=false
 ```
 

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -94,7 +94,12 @@ request whenever a guardrail workflow applies to the caller:
 }
 ```
 
-The request is answered with `403`. Route that traffic through the
+The request is answered with `403`. A passthrough workflow is matched on the
+model read from the provider-native body, and that read is best effort, so an
+inference call whose model GoModel cannot read is refused whenever *any*
+guardrail is configured — an unreadable body must not be a way around a policy.
+
+Route that traffic through the
 OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/responses`,
 `/v1/messages`), which do run the chains, or choose one of:
 

--- a/docs/features/rate-limits.mdx
+++ b/docs/features/rate-limits.mdx
@@ -223,7 +223,15 @@ Details worth knowing:
 - Token usage is counted after each response completes (streams included).
   One request can overshoot a token window before the counter catches up —
   the same behavior as other gateways that count tokens from responses.
-- Response-cache hits are served before enforcement and count nothing.
+- Response-cache hits are served before enforcement and count nothing — unless
+  the request runs a prompt-phase [guardrail](/advanced/guardrails), which is
+  enforced against first (see below), so its hits count.
+- A request a prompt-phase guardrail blocks or answers counts like any other:
+  enforcement runs before the chain, so a guardrail decision is never a free
+  request and an over-limit request never pays for an `llm_judge` call.
+- Passthrough (`/p/{provider}/...`) is rate limited like every other route,
+  but runs no guardrails; by default such a request is refused when a guardrail
+  workflow applies to the caller.
 - A realtime session counts as one request and holds one concurrency slot for
   the whole session. A batch submission counts as one request and holds no
   concurrency slot.

--- a/internal/app/init_server.go
+++ b/internal/app/init_server.go
@@ -151,6 +151,7 @@ func (b *bootstrap) initServerConfig() error {
 		RealtimeEnabled:                 appCfg.Server.RealtimeEnabled,
 		AuthVerifyEnabled:               appCfg.Server.AuthVerifyEnabled,
 		AllowPassthroughV1Alias:         &allowPassthroughV1Alias,
+		AllowUnguardedPassthrough:       appCfg.Server.AllowUnguardedPassthrough,
 		UserPathHeader:                  appCfg.Server.UserPathHeader,
 		SwaggerEnabled:                  b.swaggerEnabled,
 		Tagging:                         app.tagging.Service,

--- a/internal/gateway/inference_orchestrator.go
+++ b/internal/gateway/inference_orchestrator.go
@@ -76,6 +76,12 @@ type RequestMeta struct {
 	RequestID string
 	Endpoint  core.EndpointDescriptor
 	Workflow  *core.Workflow
+	// Admit, when set, runs as soon as the route is resolved and before any
+	// prompt-phase work. Guardrails run in that phase and can spend provider
+	// money (an llm_judge step issues its own inference), so the transport
+	// admits the request — rate limits and budgets — first. Returning an
+	// error aborts preparation with the resolved workflow attached.
+	Admit func(context.Context, *core.Workflow) error
 }
 
 // PreparedChatRequest is a translated chat request ready for cache lookup or execution.

--- a/internal/gateway/inference_prepare.go
+++ b/internal/gateway/inference_prepare.go
@@ -81,7 +81,7 @@ func prepareTranslated[Req any, Prepared any](
 	if spec.resolve != nil {
 		resolve = spec.resolve(o)
 	}
-	ctx, req, workflow, err := prepareTranslatedRequest(o, ctx, req, meta, model, provider, resolve, spec.patch(o), spec.valid, spec.patchNilMessage)
+	ctx, req, workflow, err := prepareTranslatedRequest(o, ctx, req, meta, model, provider, resolve, spec.patch(o), spec.valid, spec.patchNilMessage, meta.Admit)
 	if err != nil {
 		if workflow != nil {
 			// A patch-phase error (a guardrail block or short-circuit) still
@@ -105,6 +105,7 @@ func prepareTranslatedRequest[Req any](
 	patch func(context.Context, Req) (Req, error),
 	valid func(Req) bool,
 	patchNilMessage string,
+	admit func(context.Context, *core.Workflow) error,
 ) (context.Context, Req, *core.Workflow, error) {
 	ctx = contextWithRequestID(ctx, meta.RequestID)
 	workflow, err := o.ensureTranslatedRequestWorkflow(ctx, meta.Workflow, meta.RequestID, meta.Endpoint, model, provider)
@@ -113,6 +114,15 @@ func prepareTranslatedRequest[Req any](
 		return ctx, zero, nil, err
 	}
 	ctx = core.WithWorkflow(ctx, workflow)
+	// Admission runs before the prompt phase: a guardrail step may spend
+	// provider money deciding the request, and a decision it makes must not
+	// escape the limits the request would otherwise have been counted against.
+	if admit != nil {
+		if err := admit(ctx, workflow); err != nil {
+			var zero Req
+			return ctx, zero, workflow, err
+		}
+	}
 	if resolve != nil {
 		ctx, req, err = resolve(ctx, req, workflow)
 		if err != nil {

--- a/internal/server/guardrail_admission_test.go
+++ b/internal/server/guardrail_admission_test.go
@@ -1,0 +1,223 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/budget"
+	"github.com/enterpilot/gomodel/internal/guardrails"
+	"github.com/enterpilot/gomodel/internal/plugins"
+	"github.com/enterpilot/gomodel/pluginapi"
+)
+
+// countingPromptPlugin blocks (or answers) every prompt and counts how often
+// its prompt hook ran, standing in for a guardrail that spends provider money
+// deciding the request (llm_judge).
+type countingPromptPlugin struct {
+	calls  *int
+	action string
+}
+
+// promptHookCalls is the shared counter of the plugin instances the guardrail
+// service builds; each test run installs its own.
+var promptHookCalls int
+
+func newCountingPromptPlugin() pluginapi.Plugin {
+	return &countingPromptPlugin{calls: &promptHookCalls}
+}
+
+func (p *countingPromptPlugin) Manifest() pluginapi.Manifest {
+	return pluginapi.Manifest{
+		Name:         "counting_prompt",
+		Kinds:        []pluginapi.Kind{pluginapi.KindPrompt},
+		Guardrail:    true,
+		ConfigSchema: []pluginapi.Field{{Key: "action", Input: pluginapi.InputText}},
+	}
+}
+
+func (p *countingPromptPlugin) Init(_ context.Context, raw json.RawMessage, _ pluginapi.Host) error {
+	var cfg struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return err
+	}
+	p.action = cfg.Action
+	return nil
+}
+
+func (p *countingPromptPlugin) Close(context.Context) error { return nil }
+
+func (p *countingPromptPlugin) OnPrompt(context.Context, *pluginapi.Exchange) (pluginapi.Decision, error) {
+	*p.calls++
+	if p.action == "respond" {
+		return pluginapi.Respond("I cannot help with that."), nil
+	}
+	return pluginapi.Block(0, "policy", "blocked by test"), nil
+}
+
+func countingPromptChains(t *testing.T, action string) *plugins.Chains {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]string{"action": action})
+	return newGuardrailChains(t, nil, []guardrails.StepReference{{Ref: "counter", Step: 0}},
+		[]func() pluginapi.Plugin{newCountingPromptPlugin},
+		guardrails.Definition{Name: "counter", Type: "counting_prompt", Config: raw})
+}
+
+// exceededBudgetChecker refuses every request, standing in for a path that is
+// already over budget.
+type exceededBudgetChecker struct{ calls int }
+
+func (c *exceededBudgetChecker) Check(context.Context, budget.Subjects, time.Time) error {
+	c.calls++
+	return &budget.ExceededError{Result: budget.CheckResult{
+		Budget:    budget.Budget{Scope: budget.ScopeUserPath, Subject: "/", PeriodSeconds: budget.PeriodDailySeconds, Amount: 1},
+		PeriodEnd: time.Now().UTC().Add(time.Hour),
+		Spent:     2,
+	}}
+}
+
+// TestGuardrailDecisionsAreAdmitted covers the admission ordering around the
+// prompt phase: a request a guardrail blocks or answers is counted against the
+// rate limit like any other, and an over-limit or over-budget request is
+// refused before the chain (and its provider spend) runs at all.
+func TestGuardrailDecisionsAreAdmitted(t *testing.T) {
+	for _, action := range []string{"block", "respond"} {
+		t.Run(action+" consumes the rate limit", func(t *testing.T) {
+			promptHookCalls = 0
+			handler := phaseHandler(t, phaseProvider(), countingPromptChains(t, action))
+			handler.rateLimiter = newTestRateLimitService(t, rateLimitRuleWithRequests("/", 1))
+
+			first := doChat(t, handler, chatBody)
+			if action == "block" && first.Code != http.StatusBadRequest {
+				t.Fatalf("first status = %d, want 400 (%s)", first.Code, first.Body.String())
+			}
+			if action == "respond" && first.Code != http.StatusOK {
+				t.Fatalf("first status = %d, want 200 (%s)", first.Code, first.Body.String())
+			}
+
+			second := doChat(t, handler, chatBody)
+			if second.Code != http.StatusTooManyRequests {
+				t.Fatalf("second status = %d, want 429 — the guardrail decision did not consume the limit (%s)", second.Code, second.Body.String())
+			}
+			if !strings.Contains(second.Body.String(), "rate_limit_exceeded") {
+				t.Fatalf("second body = %s, want rate_limit_exceeded", second.Body.String())
+			}
+			if promptHookCalls != 1 {
+				t.Fatalf("prompt hook ran %d times, want 1 — the rejected request still paid for the chain", promptHookCalls)
+			}
+		})
+	}
+
+	t.Run("over budget refuses before the chain", func(t *testing.T) {
+		promptHookCalls = 0
+		handler := phaseHandler(t, phaseProvider(), countingPromptChains(t, "respond"))
+		checker := &exceededBudgetChecker{}
+		handler.budgetChecker = checker
+
+		rec := doChat(t, handler, chatBody)
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("status = %d, want 429 (%s)", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "budget_exceeded") {
+			t.Fatalf("body = %s, want budget_exceeded", rec.Body.String())
+		}
+		if promptHookCalls != 0 {
+			t.Fatalf("prompt hook ran %d times over budget, want 0", promptHookCalls)
+		}
+		if checker.calls != 1 {
+			t.Fatalf("budget checked %d times, want 1", checker.calls)
+		}
+	})
+
+	t.Run("an allowed request is counted once", func(t *testing.T) {
+		promptHookCalls = 0
+		handler := phaseHandler(t, phaseProvider(), newSystemPromptChains(t, "be safe"))
+		handler.rateLimiter = newTestRateLimitService(t, rateLimitRuleWithRequests("/", 2))
+
+		for i := range 2 {
+			if rec := doChat(t, handler, chatBody); rec.Code != http.StatusOK {
+				t.Fatalf("request %d status = %d, want 200 (%s)", i+1, rec.Code, rec.Body.String())
+			}
+		}
+		if rec := doChat(t, handler, chatBody); rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("third status = %d, want 429 (%s)", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// TestPassthroughRefusesWhenGuardrailsApply covers the passthrough policy
+// gap: /p/{provider}/... cannot run guardrail chains over provider-native
+// bodies, so a caller a guardrail workflow applies to is refused rather than
+// silently served without the policy.
+func TestPassthroughRefusesWhenGuardrailsApply(t *testing.T) {
+	chains := countingPromptChains(t, "block")
+
+	tests := []struct {
+		name            string
+		chains          *plugins.Chains
+		allowUnguarded  bool
+		wantRefused     bool
+		wantErrContains string
+	}{
+		{name: "guardrail workflow refuses", chains: chains, wantRefused: true, wantErrContains: "passthrough_guardrails_unsupported"},
+		{name: "opt-out allows", chains: chains, allowUnguarded: true},
+		{name: "no chains allows", chains: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &passthroughService{
+				pluginChains:              staticChainsResolver{chains: tt.chains},
+				allowUnguardedPassthrough: tt.allowUnguarded,
+			}
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/p/openai/v1/chat/completions", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			if got := svc.guardrailWorkflowApplies(c); got != tt.wantRefused {
+				t.Fatalf("guardrailWorkflowApplies() = %v, want %v", got, tt.wantRefused)
+			}
+			if !tt.wantRefused {
+				return
+			}
+			if err := handleError(c, guardrailsBypassedError("openai")); err != nil {
+				t.Fatalf("handleError() error = %v", err)
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403 (%s)", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tt.wantErrContains) {
+				t.Fatalf("body = %s, want %q", rec.Body.String(), tt.wantErrContains)
+			}
+		})
+	}
+}
+
+// admitOnce grants one admission per request even though translated inference
+// reaches it both before the prompt phase and from dispatch.
+func TestAdmitOnceGrantsASingleAdmission(t *testing.T) {
+	service := newTestRateLimitService(t, rateLimitRuleWithRequests("/team", 1))
+	c, _ := newRateLimitTestContext("/team")
+
+	if _, err := admitOnce(c, service, nil, rateLimitRoute{}); err != nil {
+		t.Fatalf("first admitOnce() error = %v", err)
+	}
+	if _, err := admitOnce(c, service, nil, rateLimitRoute{}); err != nil {
+		t.Fatalf("second admitOnce() error = %v — the request was counted twice", err)
+	}
+	releaseAdmission(c)
+	releaseAdmission(c)
+
+	other, _ := newRateLimitTestContext("/team")
+	if _, err := admitOnce(other, service, nil, rateLimitRoute{}); err == nil {
+		t.Fatal("a second request was admitted under a limit of 1")
+	}
+}

--- a/internal/server/guardrail_admission_test.go
+++ b/internal/server/guardrail_admission_test.go
@@ -201,6 +201,46 @@ func TestPassthroughRefusesWhenGuardrailsApply(t *testing.T) {
 			configured: true,
 			info:       &core.PassthroughRouteInfo{GenAIOperation: "chat", Model: "gpt-4.1-mini"},
 		},
+		// Only a provider that ships a passthrough semantics table names a
+		// GenAI operation, so the endpoint path decides for the providers that
+		// do not: the refusal must not be escapable by sending the same body to
+		// one of them.
+		{
+			name:            "chat path on a provider without semantics refuses",
+			chains:          chains,
+			info:            &core.PassthroughRouteInfo{NormalizedEndpoint: "chat/completions", Model: "gpt-4.1-mini"},
+			wantRefused:     true,
+			wantErrContains: "passthrough_guardrails_unsupported",
+		},
+		{
+			name:            "unreadable model on a native inference path refuses",
+			configured:      true,
+			info:            &core.PassthroughRouteInfo{NormalizedEndpoint: "v1beta/models/gemini-2.5-flash:generateContent"},
+			wantRefused:     true,
+			wantErrContains: "passthrough_guardrails_unsupported",
+		},
+		{
+			name:            "legacy completions refuses",
+			chains:          chains,
+			info:            &core.PassthroughRouteInfo{GenAIOperation: "text_completion", Model: "gpt-4.1-mini"},
+			wantRefused:     true,
+			wantErrContains: "passthrough_guardrails_unsupported",
+		},
+		{
+			name:   "model listing on a provider without semantics allows",
+			chains: chains,
+			info:   &core.PassthroughRouteInfo{NormalizedEndpoint: "models"},
+		},
+		{
+			name:   "token counting allows",
+			chains: chains,
+			info:   &core.PassthroughRouteInfo{NormalizedEndpoint: "messages/count_tokens", Model: "claude-sonnet-4-5"},
+		},
+		{
+			name:   "embeddings allow",
+			chains: chains,
+			info:   &core.PassthroughRouteInfo{GenAIOperation: "embeddings", Model: "text-embedding-3-small"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/guardrail_admission_test.go
+++ b/internal/server/guardrail_admission_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"github.com/enterpilot/gomodel/internal/budget"
+	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/guardrails"
 	"github.com/enterpilot/gomodel/internal/plugins"
 	"github.com/enterpilot/gomodel/pluginapi"
@@ -163,6 +164,8 @@ func TestPassthroughRefusesWhenGuardrailsApply(t *testing.T) {
 	tests := []struct {
 		name            string
 		chains          *plugins.Chains
+		configured      bool
+		info            *core.PassthroughRouteInfo
 		allowUnguarded  bool
 		wantRefused     bool
 		wantErrContains string
@@ -170,19 +173,51 @@ func TestPassthroughRefusesWhenGuardrailsApply(t *testing.T) {
 		{name: "guardrail workflow refuses", chains: chains, wantRefused: true, wantErrContains: "passthrough_guardrails_unsupported"},
 		{name: "opt-out allows", chains: chains, allowUnguarded: true},
 		{name: "no chains allows", chains: nil},
+		// The workflow is matched on the model read from the provider-native
+		// body. A body the gateway cannot parse leaves it empty, so a
+		// model-scoped guardrail workflow is never matched: refuse rather than
+		// let an unreadable body escape the policy.
+		{
+			name:            "opaque model on an inference call refuses",
+			configured:      true,
+			info:            &core.PassthroughRouteInfo{GenAIOperation: "chat"},
+			wantRefused:     true,
+			wantErrContains: "passthrough_guardrails_unsupported",
+		},
+		{
+			name:       "opaque model on a non-inference call allows",
+			configured: true,
+			info:       &core.PassthroughRouteInfo{},
+		},
+		// Listing models or managing files runs no guardrail even on /v1, so
+		// passthrough takes nothing away.
+		{
+			name:   "non-inference route allows even with a matching chain",
+			chains: chains,
+			info:   &core.PassthroughRouteInfo{Model: "gpt-4.1-mini"},
+		},
+		{
+			name:       "known model with no matching workflow allows",
+			configured: true,
+			info:       &core.PassthroughRouteInfo{GenAIOperation: "chat", Model: "gpt-4.1-mini"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			info := tt.info
+			if info == nil {
+				info = &core.PassthroughRouteInfo{GenAIOperation: "chat", Model: "gpt-4.1-mini"}
+			}
 			svc := &passthroughService{
-				pluginChains:              staticChainsResolver{chains: tt.chains},
+				pluginChains:              staticChainsResolver{chains: tt.chains, configured: tt.configured},
 				allowUnguardedPassthrough: tt.allowUnguarded,
 			}
 			e := echo.New()
 			req := httptest.NewRequest(http.MethodPost, "/p/openai/v1/chat/completions", nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
-			if got := svc.guardrailWorkflowApplies(c); got != tt.wantRefused {
+			if got := svc.guardrailWorkflowApplies(c, info); got != tt.wantRefused {
 				t.Fatalf("guardrailWorkflowApplies() = %v, want %v", got, tt.wantRefused)
 			}
 			if !tt.wantRefused {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -48,6 +48,7 @@ type Handler struct {
 	conversationStore            conversationstore.Store
 	normalizePassthroughV1Prefix bool
 	enabledPassthroughProviders  map[string]struct{}
+	allowUnguardedPassthrough    bool
 	realtimeEnabled              bool
 	mcpEnabled                   bool
 	mcpGateway                   *mcpgateway.Service
@@ -312,5 +313,7 @@ func (h *Handler) passthrough() *passthroughService {
 		pricingResolver:              h.pricingResolver,
 		normalizePassthroughV1Prefix: h.normalizePassthroughV1Prefix,
 		enabledPassthroughProviders:  h.enabledPassthroughProviders,
+		pluginChains:                 h.pluginChains,
+		allowUnguardedPassthrough:    h.allowUnguardedPassthrough,
 	}
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -7208,11 +7208,18 @@ func TestIsNativeBatchResultsPending(t *testing.T) {
 // staticChainsResolver returns fixed plugin chains regardless of context,
 // letting tests drive the production WorkflowRequestPatcher /
 // WorkflowBatchPreparer and the response/stream phases with explicit chains.
-type staticChainsResolver struct{ chains *plugins.Chains }
+// configured additionally stands in for a gateway that has guardrails
+// somewhere in its configuration without this request matching them.
+type staticChainsResolver struct {
+	chains     *plugins.Chains
+	configured bool
+}
 
 func (s staticChainsResolver) ChainsForContext(context.Context) *plugins.Chains {
 	return s.chains
 }
+
+func (s staticChainsResolver) HasGuardrailChains() bool { return s.configured || s.chains != nil }
 
 // A caller that carries only the user-path header (no managed key) must get
 // the same policy-filtered model list that inference enforces for that path.

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -104,6 +104,7 @@ type Config struct {
 	MCPGateway                      *mcpgateway.Service                    // MCP gateway service (nil if disabled or not wired)
 	EnabledPassthroughProviders     []string                               // Provider types enabled on /p/{provider}/... passthrough routes
 	AllowPassthroughV1Alias         *bool                                  // Allow /p/{provider}/v1/... aliases; nil defaults to true
+	AllowUnguardedPassthrough       bool                                   // Serve /p/{provider}/... to callers a guardrail workflow applies to; off by default, those requests are refused
 	UserPathHeader                  string                                 // Header carrying the request user path (default: X-GoModel-User-Path)
 	AdminEndpointsEnabled           bool                                   // Whether admin API endpoints are enabled
 	AdminUIEnabled                  bool                                   // Whether admin dashboard UI is enabled
@@ -208,6 +209,9 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 	if cfg != nil && cfg.EnabledPassthroughProviders != nil {
 		handler.setEnabledPassthroughProviders(cfg.EnabledPassthroughProviders)
+	}
+	if cfg != nil {
+		handler.allowUnguardedPassthrough = cfg.AllowUnguardedPassthrough
 	}
 	// Mirror the route-registration default below: a nil config enables realtime
 	// so the documented default and the registered route stay consistent.

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -171,8 +171,10 @@ func (s *translatedInferenceService) Messages(c *echo.Context) error {
 		}
 	}
 
+	defer releaseAdmission(c)
+
 	ctx := core.WithRequestDialect(promptEditCaptureContext(c, s.logger), core.RequestDialectAnthropicMessages)
-	ctx, prepared, workflow, err := prepareChatCompletionRequest(s, ctx, req, translatedRequestMeta(c))
+	ctx, prepared, workflow, err := prepareChatCompletionRequest(s, ctx, req, s.guardedRequestMeta(c))
 	if err != nil {
 		if short := shortCircuitOf(err); short != nil {
 			attachPreparedWorkflow(c, prepareContext(c, ctx), workflow)
@@ -253,12 +255,10 @@ func (s *translatedInferenceService) dispatchMessages(c *echo.Context, req *core
 	ctx := c.Request().Context()
 	requestID := requestIDFromContextOrHeader(c.Request())
 
-	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker,
-		rateLimitRouteFromWorkflow(workflow).withFailovers(len(s.inference().FailoverSelectors(workflow))))
+	adm, err := admitOnce(c, s.rateLimiter, s.budgetChecker, s.admissionRoute(workflow))
 	if err != nil {
 		return handleError(c, err)
 	}
-	defer adm.release()
 	ctx = adm.dispatchContext(ctx)
 
 	if req.Stream {

--- a/internal/server/messages_native.go
+++ b/internal/server/messages_native.go
@@ -69,11 +69,10 @@ func (s *translatedInferenceService) dispatchMessagesNative(c *echo.Context, req
 
 	s.observeLiveProviderAttempts(c, workflow)
 
-	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker, rateLimitRouteFromWorkflow(workflow))
+	adm, err := admitOnce(c, s.rateLimiter, s.budgetChecker, s.admissionRoute(workflow))
 	if err != nil {
 		return handleError(c, err)
 	}
-	defer adm.release()
 	ctx := adm.dispatchContext(c.Request().Context())
 
 	providerName := ""

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -18,6 +18,33 @@ type passthroughService struct {
 	pricingResolver              usage.PricingResolver
 	normalizePassthroughV1Prefix bool
 	enabledPassthroughProviders  map[string]struct{}
+	pluginChains                 PluginChainsResolver
+	allowUnguardedPassthrough    bool
+}
+
+// guardrailsBypassedError reports a passthrough request that a guardrail
+// workflow applies to. Passthrough forwards the caller's provider-native body
+// and relays the provider's answer untouched, so no guardrail chain can run
+// over them; serving the request anyway would silently drop a policy the
+// operator configured. Refusing is the fail-safe default; set
+// server.allow_unguarded_passthrough (ALLOW_UNGUARDED_PASSTHROUGH=true) to
+// accept the gap, or scope the workflow so it does not match these callers.
+func guardrailsBypassedError(providerType string) error {
+	return core.NewPermissionError(
+		"provider passthrough cannot run guardrails, and a guardrail workflow applies to this request; " +
+			"call the OpenAI-compatible endpoints (/v1/chat/completions, /v1/responses, /v1/messages) instead, " +
+			"or set server.allow_unguarded_passthrough to allow unguarded passthrough for " + providerType,
+	).WithCode("passthrough_guardrails_unsupported")
+}
+
+// guardrailWorkflowApplies reports whether the request's matched workflow runs
+// any guardrail chain.
+func (s *passthroughService) guardrailWorkflowApplies(c *echo.Context) bool {
+	if s.allowUnguardedPassthrough || s.pluginChains == nil {
+		return false
+	}
+	chains := s.pluginChains.ChainsForContext(c.Request().Context())
+	return chains != nil && (!chains.Prompt.Empty() || !chains.Response.Empty() || !chains.Stream.Empty())
 }
 
 func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
@@ -32,6 +59,9 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	}
 	if !isEnabledPassthroughProvider(providerType, s.enabledPassthroughProviders) {
 		return handleError(c, s.unsupportedPassthroughProviderError(providerType))
+	}
+	if s.guardrailWorkflowApplies(c) {
+		return handleError(c, guardrailsBypassedError(providerType))
 	}
 	if s.modelAuthorizer != nil {
 		if selector, ok := passthroughAccessSelector(s.provider, info); ok {

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -60,15 +60,15 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	if !isEnabledPassthroughProvider(providerType, s.enabledPassthroughProviders) {
 		return handleError(c, s.unsupportedPassthroughProviderError(providerType))
 	}
-	if s.guardrailWorkflowApplies(c) {
-		return handleError(c, guardrailsBypassedError(providerType))
-	}
 	if s.modelAuthorizer != nil {
 		if selector, ok := passthroughAccessSelector(s.provider, info); ok {
 			if err := s.modelAuthorizer.ValidateModelAccess(c.Request().Context(), selector); err != nil {
 				return handleError(c, err)
 			}
 		}
+	}
+	if s.guardrailWorkflowApplies(c) {
+		return handleError(c, guardrailsBypassedError(providerType))
 	}
 	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker, rateLimitRoute{provider: info.ProviderName, model: info.Model})
 	if err != nil {

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/labstack/echo/v5"
 
 	"github.com/enterpilot/gomodel/internal/auditlog"
@@ -37,15 +39,46 @@ func guardrailsBypassedError(providerType string) error {
 	).WithCode("passthrough_guardrails_unsupported")
 }
 
-// guardrailWorkflowApplies reports whether the request's matched workflow runs
-// any guardrail chain.
-func (s *passthroughService) guardrailWorkflowApplies(c *echo.Context) bool {
-	if s.allowUnguardedPassthrough || s.pluginChains == nil {
+// guardrailPresenceResolver reports whether the gateway configures any
+// guardrail chain at all. Implemented by the workflows service.
+type guardrailPresenceResolver interface {
+	HasGuardrailChains() bool
+}
+
+// guardrailWorkflowApplies reports whether a guardrail chain applies, or may
+// apply, to this passthrough request.
+//
+// The workflow of a passthrough request is matched on the model read from its
+// provider-native body, and that read is best effort: a body the gateway
+// cannot parse (an unknown dialect, a chunked or oversized payload) leaves the
+// model empty, and a model-scoped guardrail workflow is then never matched.
+// So when the model is unknown on an inference call, any guardrail anywhere in
+// the configuration counts as applying — the caller controls the body, and a
+// policy must not be escapable by making it unreadable.
+func (s *passthroughService) guardrailWorkflowApplies(c *echo.Context, info *core.PassthroughRouteInfo) bool {
+	if s.allowUnguardedPassthrough || s.pluginChains == nil || info == nil {
+		return false
+	}
+	// Guardrails only ever run on text inference, so only those routes can
+	// lose a policy by being called through passthrough. Listing models or
+	// managing files is unaffected and keeps working.
+	if strings.TrimSpace(info.GenAIOperation) != genAIOperationChat {
 		return false
 	}
 	chains := s.pluginChains.ChainsForContext(c.Request().Context())
-	return chains != nil && (!chains.Prompt.Empty() || !chains.Response.Empty() || !chains.Stream.Empty())
+	if chains != nil && (!chains.Prompt.Empty() || !chains.Response.Empty() || !chains.Stream.Empty()) {
+		return true
+	}
+	if strings.TrimSpace(info.Model) != "" {
+		return false
+	}
+	presence, ok := s.pluginChains.(guardrailPresenceResolver)
+	return ok && presence.HasGuardrailChains()
 }
+
+// genAIOperationChat is the GenAI operation passthrough route semantics give
+// text inference endpoints (chat completions, responses, Anthropic messages).
+const genAIOperationChat = "chat"
 
 func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	passthroughProvider, ok := s.provider.(core.RoutablePassthrough)
@@ -67,7 +100,7 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 			}
 		}
 	}
-	if s.guardrailWorkflowApplies(c) {
+	if s.guardrailWorkflowApplies(c, info) {
 		return handleError(c, guardrailsBypassedError(providerType))
 	}
 	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker, rateLimitRoute{provider: info.ProviderName, model: info.Model})

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/auditlog"
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/providers"
 	"github.com/enterpilot/gomodel/internal/usage"
 )
 
@@ -62,7 +63,7 @@ func (s *passthroughService) guardrailWorkflowApplies(c *echo.Context, info *cor
 	// Guardrails only ever run on text inference, so only those routes can
 	// lose a policy by being called through passthrough. Listing models or
 	// managing files is unaffected and keeps working.
-	if strings.TrimSpace(info.GenAIOperation) != genAIOperationChat {
+	if !passthroughRunsTextInference(info) {
 		return false
 	}
 	chains := s.pluginChains.ChainsForContext(c.Request().Context())
@@ -76,9 +77,63 @@ func (s *passthroughService) guardrailWorkflowApplies(c *echo.Context, info *cor
 	return ok && presence.HasGuardrailChains()
 }
 
-// genAIOperationChat is the GenAI operation passthrough route semantics give
-// text inference endpoints (chat completions, responses, Anthropic messages).
-const genAIOperationChat = "chat"
+// genAIOperationChat and genAIOperationTextCompletion are the GenAI operations
+// passthrough route semantics give text inference endpoints: chat completions,
+// responses and Anthropic messages for the first, the legacy completion
+// endpoints for the second.
+const (
+	genAIOperationChat           = "chat"
+	genAIOperationTextCompletion = "text_completion"
+)
+
+// textInferenceEndpointSuffixes are the provider-native endpoint paths that run
+// text inference, matched on the tail of the endpoint so a dialect's version
+// segment (`/v2/chat`, `/beta/completions`) still counts.
+var textInferenceEndpointSuffixes = []string{
+	"/chat/completions",
+	"/chat",
+	"/completions",
+	"/responses",
+	"/messages",
+	"/converse",
+	"/converse-stream",
+	":generatecontent",
+	":streamgeneratecontent",
+}
+
+// passthroughRunsTextInference reports whether the passthrough route generates
+// text, which is the only kind of route a guardrail chain would have run on.
+//
+// The route's GenAI operation decides it, but only a provider that ships a
+// passthrough semantics table names one, and only for the endpoints the table
+// lists. A provider without a table leaves every operation empty, so the
+// endpoint path decides those: the refusal must not be escapable by sending the
+// same body to a provider GoModel has no semantics for.
+func passthroughRunsTextInference(info *core.PassthroughRouteInfo) bool {
+	switch strings.TrimSpace(info.GenAIOperation) {
+	case genAIOperationChat, genAIOperationTextCompletion:
+		return true
+	case "":
+		return textInferenceEndpoint(providers.PassthroughEndpointPath(info))
+	default:
+		// A named non-text operation (embeddings, images, audio) runs no
+		// guardrail chain on /v1 either.
+		return false
+	}
+}
+
+func textInferenceEndpoint(path string) bool {
+	path = strings.ToLower(strings.TrimRight(path, "/"))
+	if path == "" {
+		return false
+	}
+	for _, suffix := range textInferenceEndpointSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}
 
 func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	passthroughProvider, ok := s.provider.(core.RoutablePassthrough)

--- a/internal/server/ratelimit_support.go
+++ b/internal/server/ratelimit_support.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v5"
@@ -114,6 +115,42 @@ func enforceAdmission(c *echo.Context, limiter RateLimiter, checker BudgetChecke
 		return admission{release: noopRelease}, err
 	}
 	return admission{release: release, saturatedRoute: saturated}, nil
+}
+
+// requestAdmissionKey names the admission granted to the request on the Echo
+// context. A translated inference request can reach admission twice — once
+// before its prompt-phase guardrail chain and once from dispatch — and must be
+// counted only once.
+const requestAdmissionKey = "gomodel_request_admission"
+
+type grantedAdmission struct {
+	adm         admission
+	releaseOnce sync.Once
+}
+
+func (g *grantedAdmission) release() { g.releaseOnce.Do(g.adm.release) }
+
+// admitOnce runs the shared admission sequence for the request, or returns the
+// admission it already holds. releaseAdmission must run when the request
+// finishes.
+func admitOnce(c *echo.Context, limiter RateLimiter, checker BudgetChecker, route rateLimitRoute) (admission, error) {
+	if granted, ok := c.Get(requestAdmissionKey).(*grantedAdmission); ok {
+		return granted.adm, nil
+	}
+	adm, err := enforceAdmission(c, limiter, checker, route)
+	if err != nil {
+		return adm, err
+	}
+	c.Set(requestAdmissionKey, &grantedAdmission{adm: adm})
+	return adm, nil
+}
+
+// releaseAdmission returns the concurrency slots the request holds. It is safe
+// to call repeatedly and for a request that was never admitted.
+func releaseAdmission(c *echo.Context) {
+	if granted, ok := c.Get(requestAdmissionKey).(*grantedAdmission); ok {
+		granted.release()
+	}
 }
 
 // routeSaturationDeferrableToFailover returns the rejection when it may defer

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -120,12 +120,10 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 	ctx := c.Request().Context()
 	requestID := requestIDFromContextOrHeader(c.Request())
 
-	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker,
-		rateLimitRouteFromWorkflow(workflow).withFailovers(len(s.inference().FailoverSelectors(workflow))))
+	adm, err := admitOnce(c, s.rateLimiter, s.budgetChecker, s.admissionRoute(workflow))
 	if err != nil {
 		return handleError(c, err)
 	}
-	defer adm.release()
 	ctx = adm.dispatchContext(ctx)
 
 	feedbackEnabled := hasResponseFeedbackObservers(c)
@@ -202,8 +200,9 @@ func handleTranslatedJSON[Req any](
 	if err != nil {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
+	defer releaseAdmission(c)
 
-	ctx, preparedReq, workflow, err := prepare(s, promptEditCaptureContext(c, s.logger), req, translatedRequestMeta(c))
+	ctx, preparedReq, workflow, err := prepare(s, promptEditCaptureContext(c, s.logger), req, s.guardedRequestMeta(c))
 	if err != nil {
 		if short := shortCircuitOf(err); short != nil {
 			attachPreparedWorkflow(c, prepareContext(c, ctx), workflow)
@@ -355,12 +354,10 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 	ctx := c.Request().Context()
 	requestID := requestIDFromContextOrHeader(c.Request())
 
-	adm, err := enforceAdmission(c, s.rateLimiter, s.budgetChecker,
-		rateLimitRouteFromWorkflow(workflow).withFailovers(len(s.inference().FailoverSelectors(workflow))))
+	adm, err := admitOnce(c, s.rateLimiter, s.budgetChecker, s.admissionRoute(workflow))
 	if err != nil {
 		return handleError(c, err)
 	}
-	defer adm.release()
 	ctx = adm.dispatchContext(ctx)
 
 	if req.Stream {
@@ -609,6 +606,49 @@ func translatedRequestMeta(c *echo.Context) gateway.RequestMeta {
 		Endpoint:  core.DescribeEndpoint(c.Request().Method, c.Request().URL.Path),
 		Workflow:  core.GetWorkflow(c.Request().Context()),
 	}
+}
+
+// guardedRequestMeta is the request meta for translated inference, with
+// admission wired to run before the prompt phase. A gateway with no plugin
+// chains runs no guardrails, so it keeps the plain meta and takes on no
+// per-request closure.
+func (s *translatedInferenceService) guardedRequestMeta(c *echo.Context) gateway.RequestMeta {
+	meta := translatedRequestMeta(c)
+	if s.pluginChains != nil {
+		meta.Admit = s.admitBeforePromptPhase(c)
+	}
+	return meta
+}
+
+// admitBeforePromptPhase admits the request as soon as its route is resolved,
+// before the prompt-phase guardrail chain runs. A prompt guardrail can spend
+// provider money on the gateway's behalf (an llm_judge step issues its own
+// inference) and can end the request itself with a block or a synthesized
+// answer, which used to return before admission ever ran: a chain-answered
+// request consumed no rate-limit token and passed no budget check, while still
+// paying for the judge call.
+//
+// It admits only when the request actually runs a prompt chain. Without one
+// nothing is spent or decided before dispatch, and admitting here would also
+// count response-cache hits, which are deliberately served before enforcement
+// (docs/features/rate-limits.mdx, docs/features/budgets.mdx). A request that
+// runs a prompt chain reaches the cache only after the chain has already been
+// paid for, so counting its hits is the consistent choice.
+func (s *translatedInferenceService) admitBeforePromptPhase(c *echo.Context) func(context.Context, *core.Workflow) error {
+	return func(ctx context.Context, workflow *core.Workflow) error {
+		chains := s.pluginChainsFor(ctx)
+		if chains == nil || chains.Prompt.Empty() {
+			return nil
+		}
+		_, err := admitOnce(c, s.rateLimiter, s.budgetChecker, s.admissionRoute(workflow))
+		return err
+	}
+}
+
+// admissionRoute names the resolved route a translated request is admitted
+// against, including how many failover targets could relieve a saturated one.
+func (s *translatedInferenceService) admissionRoute(workflow *core.Workflow) rateLimitRoute {
+	return rateLimitRouteFromWorkflow(workflow).withFailovers(len(s.inference().FailoverSelectors(workflow)))
 }
 
 func attachPreparedWorkflow(c *echo.Context, ctx context.Context, workflow *core.Workflow) {

--- a/internal/workflows/guardrail_presence_test.go
+++ b/internal/workflows/guardrail_presence_test.go
@@ -1,0 +1,64 @@
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/guardrails"
+	"github.com/enterpilot/gomodel/internal/plugins"
+	"github.com/enterpilot/gomodel/pluginapi"
+)
+
+// chainCatalog is a guardrails.Catalog that returns one fixed prompt chain, so
+// the service can be exercised with a workflow that runs guardrails without
+// loading real plugins.
+type chainCatalog struct{}
+
+func (chainCatalog) Len() int        { return 1 }
+func (chainCatalog) Names() []string { return []string{"stub"} }
+func (chainCatalog) BuildChains([]guardrails.StepReference) (*plugins.Chains, error) {
+	return &plugins.Chains{Prompt: &plugins.Chain{Phase: pluginapi.KindPrompt, Steps: []plugins.Step{{Order: 0}}}}, nil
+}
+
+// HasGuardrailChains tells a gateway that configures no guardrail at all from
+// one where some workflow runs them: passthrough refuses a request whose model
+// it could not read only in the second case.
+func TestServiceHasGuardrailChains(t *testing.T) {
+	global := Version{
+		ID: "global", Scope: Scope{}, ScopeKey: "global", Version: 1, Active: true, Name: "global",
+		Payload: Payload{SchemaVersion: 1, Features: FeatureFlags{Cache: true, Audit: true, Usage: true}},
+	}
+	guarded := Version{
+		ID: "model", Scope: Scope{Provider: "openai", Model: "gpt-5"}, ScopeKey: "provider_model:openai:gpt-5",
+		Version: 1, Active: true, Name: "guarded",
+		Payload: Payload{SchemaVersion: 1, Features: FeatureFlags{Guardrails: true}, Steps: []Step{{Ref: "stub", Phase: "prompt", Step: 0}}},
+	}
+
+	for _, tt := range []struct {
+		name     string
+		versions []Version
+		want     bool
+	}{
+		{name: "no guardrails", versions: []Version{global}},
+		{name: "one guarded workflow", versions: []Version{global, guarded}, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			service, err := NewService(&staticStore{versions: tt.versions}, NewCompilerWithFeatureCaps(chainCatalog{}, core.DefaultWorkflowFeatures()))
+			if err != nil {
+				t.Fatalf("NewService() error = %v", err)
+			}
+			if err := service.Refresh(context.Background()); err != nil {
+				t.Fatalf("Refresh() error = %v", err)
+			}
+			if got := service.HasGuardrailChains(); got != tt.want {
+				t.Fatalf("HasGuardrailChains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	var nilService *Service
+	if nilService.HasGuardrailChains() {
+		t.Fatal("HasGuardrailChains() on a nil service = true, want false")
+	}
+}

--- a/internal/workflows/service.go
+++ b/internal/workflows/service.go
@@ -375,6 +375,26 @@ func (s *Service) ChainsForWorkflow(workflow *core.Workflow) *plugins.Chains {
 	return compiled.Chains
 }
 
+// HasGuardrailChains reports whether any active workflow runs a guardrail
+// chain. Callers that cannot resolve the workflow of a request precisely —
+// provider passthrough, whose selector has no model when the body is opaque —
+// use it to tell "this gateway configures no guardrails at all" from "a
+// guardrail workflow may apply and was not matched".
+func (s *Service) HasGuardrailChains() bool {
+	if s == nil {
+		return false
+	}
+	for compiled := range compiledSet(s.snapshot()) {
+		if compiled == nil || compiled.Chains == nil {
+			continue
+		}
+		if !compiled.Chains.Prompt.Empty() || !compiled.Chains.Response.Empty() || !compiled.Chains.Stream.Empty() {
+			return true
+		}
+	}
+	return false
+}
+
 // StartBackgroundRefresh periodically reloads active workflows until stopped.
 func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
 	if interval <= 0 {


### PR DESCRIPTION
Two guardrail enforcement gaps found in pre-release testing.

## Prompt-phase guardrail decisions bypassed rate limits and budgets

A prompt chain that blocks or answers a request returned before `handleWithCache`, and admission only ran inside dispatch — so a blocked or guardrail-answered request consumed no rate-limit token and passed no budget check, while an `llm_judge` step had already made a real, billed model call to decide it. Verified live: under a 3 req/min limit that 429s benign traffic, guardrail-answered requests returned 200 indefinitely, over budget too.

**Ordering chosen:** when a request runs a prompt-phase chain, admission (rate limits, then budget) now runs as soon as the route is resolved and *before* the chain. Money is never spent on a judge call for a request the gateway will not serve, and a decision the chain makes is still counted. Admission is granted once per request and reused by dispatch, so nothing is counted twice.

The gate is conditional on the request actually running a prompt chain. Without one nothing is spent or decided before dispatch, so admission stays where it was and response-cache hits remain free, as `docs/features/rate-limits.mdx` and `docs/features/budgets.mdx` document. With a prompt chain the cache is consulted only after the chain has already been paid for, so counting those hits is the consistent choice; both docs now say so.

## `/p/{provider}/...` passthrough ran no guardrails, and nothing said so

The same key that got `400 keyword_block` on `/v1/chat/completions` got `200` on `/p/openai/v1/chat/completions` and `/p/deepseek/v1/chat/completions`. Passthrough routes are on by default.

Running the chains there faithfully is not possible: passthrough forwards arbitrary provider-native bodies (OpenAI, Anthropic, Gemini, Cohere dialects, and non-chat endpoints) and relays the provider's answer byte-for-byte, which is the point of the route. So the gap is made explicit and fails safe instead: a passthrough request is refused with `403 passthrough_guardrails_unsupported` whenever a guardrail workflow applies to the caller. Operators who accept the gap set `server.allow_unguarded_passthrough: true` (`ALLOW_UNGUARDED_PASSTHROUGH=true`), or scope the workflow so it does not match those callers. Passthrough is unchanged for every caller no guardrail workflow matches, and for every non-inference passthrough route (model lists, files), which run no guardrail on `/v1` either.

The workflow of a passthrough request is matched on the model read from its provider-native body, and that read is best effort. So a text-inference passthrough call whose model GoModel cannot read (chunked, oversized, or an unparsed dialect) is refused whenever *any* active workflow runs a guardrail chain — otherwise a caller could escape a model-scoped policy just by making the body unreadable.

Which routes count as text inference is decided by the route's GenAI operation, and by the endpoint path when the provider ships no passthrough semantics table (`hetzner` is enabled by default and has none) or the table does not name the endpoint. Otherwise the refusal would have been escapable by sending the same body to such a provider, or to a legacy `/completions` route. Model lists, token counts, embeddings, files and batches keep passing through.

## User-visible impact

- Guardrail blocks and guardrail-answered requests now count against rate limits and budgets; an over-limit or over-budget request is refused before any judge call.
- A response-cache hit counts only when the request runs a prompt-phase guardrail; otherwise it is still free.
- New `workflows.Service.HasGuardrailChains` reports whether any active workflow runs guardrails; passthrough uses it for the unreadable-model case.
- New `server.allow_unguarded_passthrough` / `ALLOW_UNGUARDED_PASSTHROUGH`, default `false`. Deployments that use both guardrails and passthrough for the same callers get `403` until they opt in or rescope the workflow.
- Docs updated: `docs/advanced/guardrails.mdx`, `docs/features/passthrough-api.mdx`, `docs/features/rate-limits.mdx`, `docs/features/budgets.mdx`, `.env.template`, `config/config.example.yaml`.

## Testing

- New `internal/server/guardrail_admission_test.go`: block/respond decisions consume the limit, an over-budget request never reaches the prompt hook, an allowed request is counted once, `admitOnce` grants a single admission, the passthrough refusal / opt-out / no-chains / unreadable-model / non-inference cases, and `internal/workflows`: `HasGuardrailChains` with and without a guarded workflow. All three admission subtests fail on `main`.
- `go build ./...`, `go test -race ./internal/server ./internal/gateway ./config ./internal/app ./internal/guardrails`, `go test ./...`, `make lint`, hot-path perf guard.
- Live against a gateway with a prompt-phase blocking guardrail, a 2 req/min user-path limit and a real provider: blocked prompts `400 400 429 429 429` (was `400 ×5`); benign traffic under a 3/min limit `200 200 200 429` with `requests_used: 3`; `/p/deepseek/v1/chat/completions` and `/p/deepseek/chat/completions` `403 passthrough_guardrails_unsupported`, `200` again with `ALLOW_UNGUARDED_PASSTHROUGH=true`; the same chat body sent with `Transfer-Encoding: chunked` also `403`, while `/p/deepseek/v1/models` stays `200`.

