### PR TITLE
fix(providers): adapt provider-hostile parameters and normalize Groq reasoning

### DIFF
--- a/docs/adr/0011-field-forwarding-on-translated-paths.md
+++ b/docs/adr/0011-field-forwarding-on-translated-paths.md
@@ -106,7 +106,48 @@ a provider starts accepting a field.
 | `response_format` of type `text` | Anthropic | 4 | dropped |
 | `response_format` of type `json_schema` | Anthropic | 5 | rejected |
 | `verbosity` | Anthropic | 5 | rejected |
+| `temperature` together with `top_p` | Anthropic | 4 | `top_p` dropped, `temperature` kept |
+| `metadata` | xAI `/responses` | 4 | dropped |
+| `stream_options.include_usage` | any | reserved | set by the gateway when usage tracking is on |
 | `provider` | any | reserved | set by the gateway |
+
+Two request rows deserve a note. Anthropic rejects a request that carries both
+`temperature` and `top_p` on every current model, and xAI rejects `metadata` on
+its native `/responses` endpoint; both are rule 4 because the dropped half does
+not change what the caller asked for, and rule 5 would lock OpenAI SDKs that
+fill in both sampling defaults out of Anthropic entirely. The dropped value is
+logged. `metadata` is removed only from the outbound provider request, so the
+gateway can still echo the member back to the client.
+
+### Response direction
+
+Rule 1 applies in both directions, so a member the gateway has no rule for
+comes back to the client exactly as the provider sent it. That is deliberate:
+it is how a client reads provider-native extras, and it is why vendor members
+such as Groq's `x_groq` and its `queue_time`/`prompt_time` usage timings, or
+DeepSeek's `prompt_cache_hit_tokens`/`prompt_cache_miss_tokens`, are relayed
+rather than stripped.
+
+| Field | Source | Rule | Treatment |
+|---|---|---|---|
+| any unknown member | any | 1 | forwarded untouched |
+| `message.reasoning` / `delta.reasoning` | Groq | 3 | returned as `reasoning_content` |
+| `x_groq`, `queue_time`, `prompt_time`, `completion_time` | Groq | 1 | forwarded untouched |
+| `prompt_cache_hit_tokens`, `prompt_cache_miss_tokens` | DeepSeek | 1 | forwarded untouched (`prompt_tokens_details.cached_tokens` carries the same count) |
+
+`reasoning` is rule 3 rather than rule 1 because the gateway does have a rule
+for the field: `reasoning_content` is the spelling every other adapter emits
+and the one the Responses and Messages translation layers and the dashboard
+read, so relaying Groq's spelling would make identical client code work on
+DeepSeek and silently lose the reasoning on Groq. It is renamed rather than
+duplicated: two copies of the same chain of thought would double the payload
+of every reasoning response.
+
+On the streaming path the rename is gated on a byte scan for `"reasoning"`, so
+only the reasoning deltas of a reasoning model are decoded and re-encoded;
+every other line keeps the upstream bytes. Anything that would force a decode
+of *every* chunk needs the same justification, because the verbatim relay of
+chat SSE is a deliberate hot-path property.
 
 ## Consequences
 

--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -129,7 +129,14 @@ Opus 5, Sonnet 5, and Opus 4.8/4.7 — any value, including the OpenAI SDK
 default of `temperature: 1`, is rejected upstream with a 400. GoModel drops
 both fields for those models and logs the discarded values, so clients that
 always send a temperature keep working. Older models still receive them as
-sent.
+sent, with one exception below.
+
+Anthropic treats `temperature` and `top_p` as mutually exclusive on every
+model: a request carrying both is rejected with ``400 "`temperature` and
+`top_p` cannot both be specified for this model"``. Since OpenAI-compatible
+clients routinely fill in both defaults, GoModel forwards `temperature` and
+drops `top_p` (logging the discarded value) when it sees both. Send only
+`top_p` if that is the knob you want to control.
 
 Independently of the model, when extended thinking is engaged Anthropic
 requires `temperature = 1`. GoModel drops any other temperature value (and logs

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -210,6 +210,32 @@ support, not every individual model capability exposed by an upstream provider.
   `VERTEX_PROJECT` / `VERTEX_LOCATION`. `VERTEX_AUTH_TYPE` defaults to
   Application Default Credentials (`gcp_adc`).
 
+## What GoModel normalizes in responses
+
+GoModel returns one shape per field no matter which provider answered, and
+forwards everything else exactly as the provider sent it.
+
+- **Reasoning text** comes back as `reasoning_content`, on
+  `choices[].message` and on streamed `choices[].delta`. Groq returns it as
+  `reasoning`; GoModel renames it, so the same client code reads the chain of
+  thought from Groq, DeepSeek, Anthropic, Cohere and vLLM alike.
+- **Vendor members are not stripped.** Groq's `x_groq` and its
+  `queue_time` / `prompt_time` / `completion_time` usage timings, and
+  DeepSeek's `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`, reach the
+  client untouched — that passthrough is how you get at provider-native extras
+  without waiting for a GoModel release. Read cache hits from the portable
+  `usage.prompt_tokens_details.cached_tokens` if you want provider-independent
+  code. See [ADR-0011](https://github.com/ENTERPILOT/GoModel/blob/main/docs/adr/0011-field-forwarding-on-translated-paths.md).
+- **Streams carry a final `usage` even if you did not ask for it.** With usage
+  tracking on, GoModel adds `stream_options.include_usage` to every streaming
+  request so it can price the call, and the provider's usage chunk is relayed
+  as-is; OpenAI's own API omits usage unless the client asks. Most providers
+  send it as a separate trailing chunk with an empty `choices` array, DeepSeek
+  attaches it to its last content chunk. Ignore the member, or set
+  `ENFORCE_RETURNING_USAGE_DATA=false` to stop GoModel asking for it — at the
+  cost of usage records for streamed requests on providers that only report
+  usage when asked.
+
 ## Why some providers have dedicated pages
 
 These are the providers most users hit friction on:

--- a/docs/providers/xai.mdx
+++ b/docs/providers/xai.mdx
@@ -63,3 +63,11 @@ tokens are often billed at the uncached price.
   messages — cache affinity works with no client change.
 - **Responses API:** pass `prompt_cache_key` in the request body; GoModel
   forwards it verbatim.
+
+## `metadata` on the Responses API
+
+xAI's native `/responses` endpoint rejects the standard OpenAI `metadata`
+member with `400 "Argument not supported: metadata"`. GoModel drops it from
+the outbound request (logging that it did) instead of relaying the error, so
+clients that tag every request with metadata keep working. The member is only
+removed on the way to xAI; nothing else about the request changes.

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -3838,8 +3838,10 @@ func TestConvertResponsesRequestToAnthropic(t *testing.T) {
 				if req.Temperature == nil || *req.Temperature != 0.7 {
 					t.Errorf("Temperature = %v, want 0.7", req.Temperature)
 				}
-				if req.TopP == nil || *req.TopP != 0.2 {
-					t.Errorf("TopP = %v, want 0.2", req.TopP)
+				// Anthropic rejects both sampling parameters at once, so
+				// top_p is dropped in favour of temperature.
+				if req.TopP != nil {
+					t.Errorf("TopP = %v, want nil", *req.TopP)
 				}
 				if req.MaxTokens != 1024 {
 					t.Errorf("MaxTokens = %d, want 1024", req.MaxTokens)
@@ -6157,6 +6159,70 @@ func TestRejectsSamplingParameters(t *testing.T) {
 	}
 }
 
+func TestConvertToAnthropicRequestDropsConflictingSamplingParameter(t *testing.T) {
+	ptr := func(v float64) *float64 { return &v }
+	tests := []struct {
+		name        string
+		model       string
+		temperature *float64
+		topP        *float64
+		wantTemp    *float64
+		wantTopP    *float64
+	}{
+		{
+			name:        "both sent keeps temperature only",
+			model:       "claude-haiku-4-5-20251001",
+			temperature: ptr(0.5),
+			topP:        ptr(0.9),
+			wantTemp:    ptr(0.5),
+		},
+		{
+			name:        "temperature alone is forwarded",
+			model:       "claude-haiku-4-5-20251001",
+			temperature: ptr(0.5),
+			wantTemp:    ptr(0.5),
+		},
+		{
+			name:     "top_p alone is forwarded",
+			model:    "claude-haiku-4-5-20251001",
+			topP:     ptr(0.9),
+			wantTopP: ptr(0.9),
+		},
+		{
+			name:        "models rejecting sampling lose both",
+			model:       "claude-opus-4-8",
+			temperature: ptr(0.5),
+			topP:        ptr(0.9),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := convertToAnthropicRequest(&core.ChatRequest{
+				Model:       tt.model,
+				Messages:    []core.Message{{Role: "user", Content: "hi"}},
+				Temperature: tt.temperature,
+				TopP:        tt.topP,
+			})
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest: %v", err)
+			}
+			if !equalFloatPtr(out.Temperature, tt.wantTemp) {
+				t.Errorf("temperature = %v, want %v", out.Temperature, tt.wantTemp)
+			}
+			if !equalFloatPtr(out.TopP, tt.wantTopP) {
+				t.Errorf("top_p = %v, want %v", out.TopP, tt.wantTopP)
+			}
+		})
+	}
+}
+
+func equalFloatPtr(got, want *float64) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	return *got == *want
+}
+
 func TestRejectsForcedToolChoice(t *testing.T) {
 	for model, want := range map[string]bool{
 		"claude-fable-5-1":          true,
@@ -6184,7 +6250,9 @@ func TestConvertToAnthropicRequest_DropsSamplingForModelsThatRejectIt(t *testing
 	}{
 		{name: "fable 5.1 drops temperature and top_p", model: "claude-fable-5-1"},
 		{name: "opus 4.7 drops temperature and top_p", model: "claude-opus-4-7"},
-		{name: "sonnet 4.6 keeps sampling parameters", model: "claude-sonnet-4-6", wantKept: true},
+		// Models that still accept sampling parameters keep temperature;
+		// top_p goes because Anthropic refuses the two together.
+		{name: "sonnet 4.6 keeps temperature", model: "claude-sonnet-4-6", wantKept: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -6198,8 +6266,8 @@ func TestConvertToAnthropicRequest_DropsSamplingForModelsThatRejectIt(t *testing
 				t.Fatalf("convertToAnthropicRequest() error = %v", err)
 			}
 			if tt.wantKept {
-				if out.Temperature == nil || *out.Temperature != temp || out.TopP == nil || *out.TopP != topP {
-					t.Fatalf("Temperature = %v, TopP = %v, want %v and %v", out.Temperature, out.TopP, temp, topP)
+				if out.Temperature == nil || *out.Temperature != temp || out.TopP != nil {
+					t.Fatalf("Temperature = %v, TopP = %v, want %v and nil", out.Temperature, out.TopP, temp)
 				}
 				return
 			}

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -400,6 +400,7 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 	}
 
 	dropUnsupportedSamplingParameters(anthropicReq)
+	dropConflictingSamplingParameter(anthropicReq)
 
 	if effort := resolveAnthropicReasoningEffort(req); effort != "" {
 		applyReasoning(anthropicReq, req.Model, effort)
@@ -489,6 +490,23 @@ func dropUnsupportedSamplingParameters(req *anthropicRequest) {
 	}
 	slog.Warn("dropping sampling parameters the model does not accept", attrs...)
 	req.Temperature = nil
+	req.TopP = nil
+}
+
+// dropConflictingSamplingParameter drops top_p when the caller sent both
+// temperature and top_p. Anthropic documents the two as mutually exclusive
+// ("we generally recommend altering temperature or top_p, but not both") and
+// every current model answers a request carrying both with a 400
+// ("`temperature` and `top_p` cannot both be specified for this model"), so an
+// OpenAI SDK that fills in both defaults could not reach Anthropic at all.
+// temperature is kept because it is the parameter OpenAI clients actually vary
+// and the one Anthropic's own guidance treats as primary.
+func dropConflictingSamplingParameter(req *anthropicRequest) {
+	if req.Temperature == nil || req.TopP == nil {
+		return
+	}
+	slog.Warn("dropping top_p; Anthropic accepts only one of temperature and top_p",
+		"model", req.Model, "temperature", *req.Temperature, "top_p", *req.TopP)
 	req.TopP = nil
 }
 

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -80,14 +80,26 @@ func (p *Provider) SetBaseURL(url string) {
 	p.compat.SetBaseURL(url)
 }
 
-// ChatCompletion sends a chat completion request to Groq
+// ChatCompletion sends a chat completion request to Groq, renaming Groq's
+// "reasoning" member to GoModel's canonical "reasoning_content".
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
-	return p.compat.ChatCompletion(ctx, req)
+	resp, err := p.compat.ChatCompletion(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	normalizeChatResponse(resp)
+	return resp, nil
 }
 
-// StreamChatCompletion returns a raw response body for streaming (caller must close)
+// StreamChatCompletion returns a response body for streaming (caller must
+// close). Reasoning deltas are renamed to "reasoning_content"; every other
+// line is relayed byte for byte.
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	return p.compat.StreamChatCompletion(ctx, req)
+	stream, err := p.compat.StreamChatCompletion(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeChatStream(stream), nil
 }
 
 // ListModels retrieves the list of available models from Groq

--- a/internal/providers/groq/reasoning_response.go
+++ b/internal/providers/groq/reasoning_response.go
@@ -1,0 +1,144 @@
+package groq
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// Groq returns the chain of thought under "reasoning", while GoModel's own
+// canonical spelling on /v1/chat/completions is "reasoning_content": that is
+// what the Anthropic, DeepSeek, Cohere and vLLM adapters emit, what the
+// Responses and Messages translation layers read, and what the dashboard
+// renders. Relaying Groq's spelling makes the same client code work on
+// DeepSeek and silently lose the reasoning on Groq, so the member is renamed
+// rather than duplicated: two copies of the same chain of thought would double
+// the payload of every reasoning response, and clients that want Groq's own
+// wire shape can still reach it through the passthrough route.
+const (
+	groqReasoningKey = "reasoning"
+	canonicalKey     = "reasoning_content"
+)
+
+// normalizeChatResponse renames the reasoning member on every choice of a
+// buffered chat completion. A response that already carries
+// "reasoning_content" is left alone.
+func normalizeChatResponse(resp *core.ChatResponse) {
+	if resp == nil {
+		return
+	}
+	for i := range resp.Choices {
+		fields := resp.Choices[i].Message.ExtraFields
+		raw := fields.Lookup(groqReasoningKey)
+		if raw == nil || fields.Lookup(canonicalKey) != nil {
+			continue
+		}
+		merged, err := core.MergeUnknownJSONFields(fields.Without(groqReasoningKey), map[string]json.RawMessage{
+			canonicalKey: raw,
+		})
+		if err != nil {
+			// Leave the upstream member in place rather than lose the text.
+			continue
+		}
+		resp.Choices[i].Message.ExtraFields = merged
+	}
+}
+
+// sseDataPrefix introduces the JSON payload of an SSE event.
+var sseDataPrefix = []byte("data: ")
+
+// reasoningMarker gates the per-chunk decode. Chunks without it — every
+// content delta, the role chunk and the terminal [DONE] — are relayed with
+// their original bytes, so only the reasoning deltas of a reasoning model pay
+// for a re-encode.
+var reasoningMarker = []byte(`"reasoning"`)
+
+// normalizeChatStream renames the reasoning delta member on a chat
+// completions SSE stream. Lines that are not data events, and data events
+// that do not mention "reasoning", pass through byte for byte.
+func normalizeChatStream(stream io.ReadCloser) io.ReadCloser {
+	if stream == nil {
+		return nil
+	}
+	return &reasoningStream{src: bufio.NewReader(stream), closer: stream}
+}
+
+type reasoningStream struct {
+	src     *bufio.Reader
+	closer  io.Closer
+	pending bytes.Buffer
+	err     error
+}
+
+func (s *reasoningStream) Read(p []byte) (int, error) {
+	for s.pending.Len() == 0 {
+		if s.err != nil {
+			return 0, s.err
+		}
+		line, err := s.src.ReadBytes('\n')
+		s.err = err
+		if len(line) > 0 {
+			s.pending.Write(renameReasoningLine(line))
+		}
+	}
+	return s.pending.Read(p)
+}
+
+func (s *reasoningStream) Close() error { return s.closer.Close() }
+
+// renameReasoningLine rewrites one SSE line, returning the input unchanged
+// whenever the rename does not apply or the payload does not parse.
+func renameReasoningLine(line []byte) []byte {
+	if !bytes.HasPrefix(line, sseDataPrefix) || !bytes.Contains(line, reasoningMarker) {
+		return line
+	}
+	payload := bytes.TrimRight(line[len(sseDataPrefix):], "\r\n")
+	var chunk map[string]any
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return line
+	}
+	if !renameReasoningDeltas(chunk) {
+		return line
+	}
+	encoded, err := json.Marshal(chunk)
+	if err != nil {
+		return line
+	}
+	out := make([]byte, 0, len(sseDataPrefix)+len(encoded)+1)
+	out = append(out, sseDataPrefix...)
+	out = append(out, encoded...)
+	return append(out, '\n')
+}
+
+// renameReasoningDeltas reports whether it changed the decoded chunk.
+func renameReasoningDeltas(chunk map[string]any) bool {
+	choices, ok := chunk["choices"].([]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	for _, entry := range choices {
+		choice, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		delta, ok := choice["delta"].(map[string]any)
+		if !ok {
+			continue
+		}
+		value, ok := delta[groqReasoningKey]
+		if !ok {
+			continue
+		}
+		if _, exists := delta[canonicalKey]; !exists {
+			delta[canonicalKey] = value
+		}
+		delete(delta, groqReasoningKey)
+		changed = true
+	}
+	return changed
+}

--- a/internal/providers/groq/reasoning_response.go
+++ b/internal/providers/groq/reasoning_response.go
@@ -34,10 +34,16 @@ func normalizeChatResponse(resp *core.ChatResponse) {
 	for i := range resp.Choices {
 		fields := resp.Choices[i].Message.ExtraFields
 		raw := fields.Lookup(groqReasoningKey)
-		if raw == nil || fields.Lookup(canonicalKey) != nil {
+		if raw == nil {
 			continue
 		}
-		merged, err := core.MergeUnknownJSONFields(fields.Without(groqReasoningKey), map[string]json.RawMessage{
+		stripped := fields.Without(groqReasoningKey)
+		if fields.Lookup(canonicalKey) != nil {
+			// Already canonical: drop the duplicate spelling only.
+			resp.Choices[i].Message.ExtraFields = stripped
+			continue
+		}
+		merged, err := core.MergeUnknownJSONFields(stripped, map[string]json.RawMessage{
 			canonicalKey: raw,
 		})
 		if err != nil {
@@ -97,11 +103,15 @@ func renameReasoningLine(line []byte) []byte {
 		return line
 	}
 	payload := bytes.TrimRight(line[len(sseDataPrefix):], "\r\n")
-	var chunk map[string]any
+	// Members are decoded as raw JSON and re-emitted byte for byte: a
+	// map[string]any round trip would reformat every number it touches,
+	// silently truncating integers beyond 2^53 in unrelated vendor data.
+	var chunk map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &chunk); err != nil {
 		return line
 	}
-	if !renameReasoningDeltas(chunk) {
+	renamed, err := renameReasoningDeltas(chunk)
+	if err != nil || !renamed {
 		return line
 	}
 	encoded, err := json.Marshal(chunk)
@@ -114,31 +124,62 @@ func renameReasoningLine(line []byte) []byte {
 	return append(out, '\n')
 }
 
-// renameReasoningDeltas reports whether it changed the decoded chunk.
-func renameReasoningDeltas(chunk map[string]any) bool {
-	choices, ok := chunk["choices"].([]any)
-	if !ok {
-		return false
+// renameReasoningDeltas rewrites chunk in place and reports whether anything
+// changed. Every member it does not rename keeps its original raw bytes.
+func renameReasoningDeltas(chunk map[string]json.RawMessage) (bool, error) {
+	var choices []json.RawMessage
+	if err := json.Unmarshal(chunk["choices"], &choices); err != nil {
+		return false, err
 	}
 	changed := false
-	for _, entry := range choices {
-		choice, ok := entry.(map[string]any)
-		if !ok {
+	for i, raw := range choices {
+		var choice map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &choice); err != nil {
+			return false, err
+		}
+		delta, err := renamedDelta(choice["delta"])
+		if err != nil {
+			return false, err
+		}
+		if delta == nil {
 			continue
 		}
-		delta, ok := choice["delta"].(map[string]any)
-		if !ok {
-			continue
+		choice["delta"] = delta
+		encoded, err := json.Marshal(choice)
+		if err != nil {
+			return false, err
 		}
-		value, ok := delta[groqReasoningKey]
-		if !ok {
-			continue
-		}
-		if _, exists := delta[canonicalKey]; !exists {
-			delta[canonicalKey] = value
-		}
-		delete(delta, groqReasoningKey)
+		choices[i] = encoded
 		changed = true
 	}
-	return changed
+	if !changed {
+		return false, nil
+	}
+	encoded, err := json.Marshal(choices)
+	if err != nil {
+		return false, err
+	}
+	chunk["choices"] = encoded
+	return true, nil
+}
+
+// renamedDelta returns the re-encoded delta object, or nil when it carries no
+// reasoning member to rename.
+func renamedDelta(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var delta map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &delta); err != nil {
+		return nil, err
+	}
+	value, ok := delta[groqReasoningKey]
+	if !ok {
+		return nil, nil
+	}
+	if _, exists := delta[canonicalKey]; !exists {
+		delta[canonicalKey] = value
+	}
+	delete(delta, groqReasoningKey)
+	return json.Marshal(delta)
 }

--- a/internal/providers/groq/reasoning_response_test.go
+++ b/internal/providers/groq/reasoning_response_test.go
@@ -24,9 +24,10 @@ func TestNormalizeChatResponse(t *testing.T) {
 			absent:  `"reasoning":`,
 		},
 		{
-			name:    "existing reasoning_content wins",
+			name:    "existing reasoning_content wins and the duplicate goes",
 			message: `{"role":"assistant","content":"4","reasoning":"drop","reasoning_content":"keep"}`,
 			want:    `"reasoning_content":"keep"`,
+			absent:  `"reasoning":`,
 		},
 		{
 			name:    "other members are untouched",
@@ -88,6 +89,17 @@ func TestNormalizeChatStream(t *testing.T) {
 			name: "the word reasoning in content is not rewritten",
 			in:   "data: {\"choices\":[{\"delta\":{\"content\":\"the \\\"reasoning\\\" step\"}}]}\n\n",
 			want: "data: {\"choices\":[{\"delta\":{\"content\":\"the \\\"reasoning\\\" step\"}}]}\n\n",
+		},
+		{
+			name: "duplicate spellings collapse onto the canonical one",
+			in:   "data: {\"choices\":[{\"delta\":{\"reasoning\":\"drop\",\"reasoning_content\":\"keep\"}}]}\n\n",
+			want: "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"keep\"}}]}\n\n",
+		},
+		{
+			// A map[string]any round trip would round this to ...992.
+			name: "unrelated numbers keep full precision",
+			in:   "data: {\"vendor_counter\":9007199254740993,\"choices\":[{\"delta\":{\"reasoning\":\"We\"}}]}\n\n",
+			want: "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"We\"}}],\"vendor_counter\":9007199254740993}\n\n",
 		},
 		{
 			name: "unparsable payloads are relayed unchanged",

--- a/internal/providers/groq/reasoning_response_test.go
+++ b/internal/providers/groq/reasoning_response_test.go
@@ -1,0 +1,120 @@
+package groq
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestNormalizeChatResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+		absent  string
+	}{
+		{
+			name:    "groq reasoning is renamed",
+			message: `{"role":"assistant","content":"4","reasoning":"Answer 4."}`,
+			want:    `"reasoning_content":"Answer 4."`,
+			absent:  `"reasoning":`,
+		},
+		{
+			name:    "existing reasoning_content wins",
+			message: `{"role":"assistant","content":"4","reasoning":"drop","reasoning_content":"keep"}`,
+			want:    `"reasoning_content":"keep"`,
+		},
+		{
+			name:    "other members are untouched",
+			message: `{"role":"assistant","content":"4","channel":"final"}`,
+			want:    `"channel":"final"`,
+			absent:  `"reasoning_content"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var msg core.ResponseMessage
+			if err := json.Unmarshal([]byte(tt.message), &msg); err != nil {
+				t.Fatalf("unmarshal message: %v", err)
+			}
+			resp := &core.ChatResponse{Choices: []core.Choice{{Message: msg}}}
+
+			normalizeChatResponse(resp)
+
+			encoded, err := json.Marshal(resp.Choices[0].Message)
+			if err != nil {
+				t.Fatalf("marshal message: %v", err)
+			}
+			if !strings.Contains(string(encoded), tt.want) {
+				t.Errorf("message = %s, want it to contain %s", encoded, tt.want)
+			}
+			if tt.absent != "" && strings.Contains(string(encoded), tt.absent) {
+				t.Errorf("message = %s, want it to drop %s", encoded, tt.absent)
+			}
+		})
+	}
+}
+
+func TestNormalizeChatResponseNilIsSafe(t *testing.T) {
+	normalizeChatResponse(nil)
+}
+
+func TestNormalizeChatStream(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "reasoning delta is renamed",
+			in:   "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"We\"}}]}\n\n",
+			want: "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"We\"},\"index\":0}]}\n\n",
+		},
+		{
+			name: "content deltas are relayed byte for byte",
+			in:   "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n",
+			want: "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n",
+		},
+		{
+			name: "reasoning_content is left alone",
+			in:   "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"We\"}}]}\n\n",
+			want: "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"We\"}}]}\n\n",
+		},
+		{
+			name: "the word reasoning in content is not rewritten",
+			in:   "data: {\"choices\":[{\"delta\":{\"content\":\"the \\\"reasoning\\\" step\"}}]}\n\n",
+			want: "data: {\"choices\":[{\"delta\":{\"content\":\"the \\\"reasoning\\\" step\"}}]}\n\n",
+		},
+		{
+			name: "unparsable payloads are relayed unchanged",
+			in:   "data: {\"reasoning\"\n\n",
+			want: "data: {\"reasoning\"\n\n",
+		},
+		{
+			name: "comments and empty streams survive",
+			in:   ": ping\n\n",
+			want: ": ping\n\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := io.ReadAll(normalizeChatStream(io.NopCloser(strings.NewReader(tt.in))))
+			if err != nil {
+				t.Fatalf("read stream: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("stream = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeChatStreamNilIsSafe(t *testing.T) {
+	if got := normalizeChatStream(nil); got != nil {
+		t.Errorf("normalizeChatStream(nil) = %v, want nil", got)
+	}
+}

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -249,9 +250,27 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 	return p.compat.ListModels(ctx)
 }
 
+// adaptResponsesRequest drops Responses members xAI's native /responses
+// endpoint refuses. xAI answers a request carrying "metadata" with
+// 400 "Argument not supported: metadata", even though it is a standard
+// OpenAI Responses member; it is a caller-side label that does not affect
+// generation, so dropping it is preferable to relaying an error the client
+// cannot act on. The caller's request is left untouched so the gateway can
+// still echo the member back to the client.
+func adaptResponsesRequest(req *core.ResponsesRequest) *core.ResponsesRequest {
+	if req == nil || len(req.Metadata) == 0 {
+		return req
+	}
+	slog.Warn("dropping metadata; xai rejects the member on /responses",
+		"model", req.Model, "keys", len(req.Metadata))
+	adapted := *req
+	adapted.Metadata = nil
+	return &adapted
+}
+
 // Responses sends a Responses API request to xAI's native /responses endpoint.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return p.compat.Responses(ctx, req)
+	return p.compat.Responses(ctx, adaptResponsesRequest(req))
 }
 
 // StreamResponses returns a normalized streaming Responses API body.
@@ -260,7 +279,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 // synthesize a terminal `data: [DONE]` marker on completed streams. Callers
 // remain responsible for closing the returned stream.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return p.compat.StreamResponses(ctx, req)
+	return p.compat.StreamResponses(ctx, adaptResponsesRequest(req))
 }
 
 // Embeddings sends an embeddings request to xAI

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -404,6 +404,61 @@ func TestChatCompletion(t *testing.T) {
 	}
 }
 
+func TestResponsesDropsMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		stream   bool
+	}{
+		{name: "non-streaming drops metadata", metadata: map[string]string{"team": "alpha"}},
+		{name: "streaming drops metadata", metadata: map[string]string{"team": "alpha"}, stream: true},
+		{name: "no metadata is a no-op", metadata: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read body: %v", err)
+					return
+				}
+				if err := json.Unmarshal(raw, &body); err != nil {
+					t.Errorf("unmarshal body: %v", err)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","status":"completed"}`))
+			}))
+			defer server.Close()
+
+			provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			req := &core.ResponsesRequest{Model: "grok-4.3", Metadata: tt.metadata}
+			var err error
+			if tt.stream {
+				var stream io.ReadCloser
+				stream, err = provider.StreamResponses(context.Background(), req)
+				if stream != nil {
+					_ = stream.Close()
+				}
+			} else {
+				_, err = provider.Responses(context.Background(), req)
+			}
+			if err != nil {
+				t.Fatalf("responses: %v", err)
+			}
+			if _, ok := body["metadata"]; ok {
+				t.Errorf("outbound body carries metadata: %v", body["metadata"])
+			}
+			if len(tt.metadata) > 0 && req.Metadata == nil {
+				t.Error("caller request was mutated; metadata must survive for the client echo")
+			}
+		})
+	}
+}
+
 func TestStreamChatCompletion(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Three leftover compatibility gaps found in pre-release testing, all verified live before and after.

**Anthropic: `temperature` + `top_p` together returned a 400.** Every current Claude model (haiku 4.5, sonnet 4.5/4.6, opus 4.5/4.6, …) rejects a request carrying both with ``"`temperature` and `top_p` cannot both be specified for this model"``, so any OpenAI SDK that fills in both defaults could not reach Anthropic through `/v1/chat/completions` or `/v1/responses` at all. GoModel now forwards `temperature` and drops `top_p`, logging the discarded value, next to the existing per-model sampling drop.

**xAI: `metadata` returned a 400 on `/v1/responses`.** `metadata` is a standard OpenAI Responses member; xAI answers `"Argument not supported: metadata"`. It is dropped from the outbound provider request only, so the client-visible request is untouched and the gateway can still echo it back.

**Groq returned the chain of thought as `reasoning`, not `reasoning_content`.** `reasoning_content` is what every other adapter emits and what the Responses/Messages translation layers and the dashboard read, so identical client code worked on DeepSeek and silently lost the reasoning on Groq. It is now renamed on `/v1/chat/completions`, buffered and streamed, which also makes Groq reasoning reach `/v1/responses` and `/v1/messages`. Renamed rather than duplicated: two copies of the same chain of thought would double the payload of every reasoning response. On the stream the rewrite is gated on a byte scan for `"reasoning"`, so only reasoning deltas are decoded and re-encoded and every other line keeps the upstream bytes — the verbatim SSE relay stays intact for the common case.

Two related findings are documented rather than changed, with the reasoning recorded in ADR-0011:

- Vendor response members (`x_groq`, Groq's `queue_time`/`prompt_time` usage timings, DeepSeek's `prompt_cache_hit_tokens`/`prompt_cache_miss_tokens`) stay. ADR-0011 rule 1 forwards unknown members untouched in both directions, and stripping them would remove the only route to provider-native extras. `prompt_tokens_details.cached_tokens` already carries the portable cache count.
- Streams carry a final `usage` even when the client did not send `stream_options.include_usage`, because the gateway adds it to price the call. Suppressing it would have to happen downstream of the usage observer, in the shared server streaming path for every provider; `ENFORCE_RETURNING_USAGE_DATA=false` is the existing opt-out. Documented in the providers overview.

Docs: ADR-0011 gains the new request rows and a response-direction table; `providers/anthropic.mdx`, `providers/xai.mdx` and a new "What GoModel normalizes in responses" section in `providers/overview.mdx`.

Tested: table-driven unit tests for each change (Anthropic sampling combinations, xAI metadata on both Responses paths, Groq buffered + streamed rename including the byte-for-byte passthrough cases); `go test ./...`, `go test -race ./internal/providers/...`, `make lint`, perf guard. Live against a real gateway on all four providers: both Anthropic 400s gone, xAI metadata request succeeds, Groq reasoning arrives as `reasoning_content` on chat (buffered and streamed), `/v1/responses` and `/v1/messages`, and Groq non-reasoning chunks and DeepSeek streams are unchanged.
