### PR TITLE
test: add echotest and providertest helper packages

### DIFF
--- a/internal/echotest/echotest.go
+++ b/internal/echotest/echotest.go
@@ -1,0 +1,131 @@
+// Package echotest builds echo contexts for handler unit tests so each test
+// states only what differs: method, target, body, and the occasional header
+// or path value.
+package echotest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+)
+
+// Option adjusts the request or context built by Request.
+type Option func(*settings)
+
+type settings struct {
+	headers     http.Header
+	pathValues  echo.PathValues
+	path        string
+	values      map[string]any
+	contentType string
+}
+
+// WithHeader sets a request header.
+func WithHeader(key, value string) Option {
+	return func(s *settings) { s.headers.Set(key, value) }
+}
+
+// WithPathValue binds a route parameter (c.Param) for the handler.
+func WithPathValue(name, value string) Option {
+	return func(s *settings) {
+		s.pathValues = append(s.pathValues, echo.PathValue{Name: name, Value: value})
+	}
+}
+
+// WithPath sets the route path template (c.Path), for handlers that inspect it.
+func WithPath(path string) Option {
+	return func(s *settings) { s.path = path }
+}
+
+// WithValue stores a context value (c.Set) before the handler runs, for
+// values middleware would normally provide.
+func WithValue(key string, value any) Option {
+	return func(s *settings) { s.values[key] = value }
+}
+
+// WithContentType overrides the Content-Type set for a non-nil body.
+func WithContentType(contentType string) Option {
+	return func(s *settings) { s.contentType = contentType }
+}
+
+// Request builds an echo context and recorder for a handler call.
+//
+// body may be nil (no body), a string or []byte (sent verbatim), an io.Reader,
+// or any other value, which is JSON-encoded. A non-nil body gets a JSON
+// Content-Type unless WithContentType overrides it.
+func Request(t testing.TB, method, target string, body any, opts ...Option) (*echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	s := settings{headers: http.Header{}, values: map[string]any{}, contentType: echo.MIMEApplicationJSON}
+	for _, opt := range opts {
+		opt(&s)
+	}
+
+	req := httptest.NewRequest(method, target, bodyReader(t, body))
+	if body != nil {
+		req.Header.Set(echo.HeaderContentType, s.contentType)
+	}
+	maps.Copy(req.Header, s.headers)
+
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	if s.path != "" {
+		c.SetPath(s.path)
+	}
+	if len(s.pathValues) > 0 {
+		c.SetPathValues(s.pathValues)
+	}
+	for key, value := range s.values {
+		c.Set(key, value)
+	}
+	return c, rec
+}
+
+// Get is Request for a GET with no body.
+func Get(t testing.TB, target string, opts ...Option) (*echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	return Request(t, http.MethodGet, target, nil, opts...)
+}
+
+// Post is Request for a POST with a JSON body.
+func Post(t testing.TB, target string, body any, opts ...Option) (*echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	return Request(t, http.MethodPost, target, body, opts...)
+}
+
+// Decode unmarshals the recorded JSON response body into T, failing the test
+// when it is not valid JSON for T.
+func Decode[T any](t testing.TB, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+	var out T
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("echotest: decode response body as %T: %v\nbody: %s", out, err, rec.Body.String())
+	}
+	return out
+}
+
+func bodyReader(t testing.TB, body any) io.Reader {
+	t.Helper()
+	switch b := body.(type) {
+	case nil:
+		return nil
+	case string:
+		return strings.NewReader(b)
+	case []byte:
+		return bytes.NewReader(b)
+	case io.Reader:
+		return b
+	default:
+		data, err := json.Marshal(b)
+		if err != nil {
+			t.Fatalf("echotest: marshal request body %T: %v", body, err)
+		}
+		return bytes.NewReader(data)
+	}
+}

--- a/internal/echotest/echotest_test.go
+++ b/internal/echotest/echotest_test.go
@@ -1,7 +1,9 @@
 package echotest
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -40,4 +42,20 @@ func TestRequest_RawBodiesAndContentType(t *testing.T) {
 	c, _ = Get(t, "/x")
 	assert.Empty(t, c.Request().Header.Get(echo.HeaderContentType))
 	assert.Equal(t, http.NoBody, c.Request().Body)
+}
+
+func TestRequest_SendsRawBodyFormsVerbatim(t *testing.T) {
+	for name, body := range map[string]any{
+		"string": "plain text",
+		"bytes":  []byte("plain text"),
+		"reader": strings.NewReader("plain text"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, _ := Post(t, "/x", body)
+			got, err := io.ReadAll(c.Request().Body)
+			require.NoError(t, err)
+			assert.Equal(t, "plain text", string(got))
+			assert.Equal(t, echo.MIMEApplicationJSON, c.Request().Header.Get(echo.HeaderContentType))
+		})
+	}
 }

--- a/internal/echotest/echotest_test.go
+++ b/internal/echotest/echotest_test.go
@@ -1,0 +1,43 @@
+package echotest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequest_EncodesBodyAndBindsOptions(t *testing.T) {
+	c, rec := Request(t, http.MethodPut, "/items/:id?verbose=1", map[string]string{"name": "a"},
+		WithPathValue("id", "42"),
+		WithHeader("X-Test", "yes"),
+		WithValue("user", "u1"),
+		WithPath("/items/:id"),
+	)
+
+	assert.Equal(t, http.MethodPut, c.Request().Method)
+	assert.Equal(t, "42", c.Param("id"))
+	assert.Equal(t, "1", c.QueryParam("verbose"))
+	assert.Equal(t, "yes", c.Request().Header.Get("X-Test"))
+	assert.Equal(t, echo.MIMEApplicationJSON, c.Request().Header.Get(echo.HeaderContentType))
+	assert.Equal(t, "u1", c.Get("user"))
+	assert.Equal(t, "/items/:id", c.Path())
+
+	var body map[string]string
+	require.NoError(t, c.Bind(&body))
+	assert.Equal(t, "a", body["name"])
+
+	require.NoError(t, c.JSON(http.StatusOK, map[string]int{"n": 1}))
+	assert.Equal(t, 1, Decode[map[string]int](t, rec)["n"])
+}
+
+func TestRequest_RawBodiesAndContentType(t *testing.T) {
+	c, _ := Post(t, "/x", `{"raw":true}`, WithContentType("text/plain"))
+	assert.Equal(t, "text/plain", c.Request().Header.Get(echo.HeaderContentType))
+
+	c, _ = Get(t, "/x")
+	assert.Empty(t, c.Request().Header.Get(echo.HeaderContentType))
+	assert.Equal(t, http.NoBody, c.Request().Body)
+}

--- a/internal/providers/providertest/chat_compatible.go
+++ b/internal/providers/providertest/chat_compatible.go
@@ -2,6 +2,7 @@ package providertest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -33,10 +34,12 @@ const ModelsJSON = `{"object":"list","data":[{"id":"` + Model + `","object":"mod
 // EmbeddingsJSON is a one-vector embeddings reply.
 const EmbeddingsJSON = `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"model":"` + Model + `","usage":{"prompt_tokens":2,"total_tokens":2}}`
 
-// Model and Reply are the model ID and assistant text used by the fixtures.
+// Model, Prompt, and Reply are the model ID, user text, and assistant text
+// used by the fixtures and the contract requests.
 const (
-	Model = "test-model"
-	Reply = "hello"
+	Model  = "test-model"
+	Prompt = "hi"
+	Reply  = "hello"
 )
 
 // ChatCompatible describes a provider built on the shared OpenAI-compatible
@@ -98,21 +101,19 @@ func AssertChatCompatible(t *testing.T, p ChatCompatible) {
 		}
 	})
 
-	t.Run("chat completion", func(t *testing.T) {
+	t.Run("chat completion via registered factory", func(t *testing.T) {
 		server, capture := JSONServer(t, http.StatusOK, ChatCompletionJSON)
-		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		provider := p.Registration.New(providers.ProviderConfig{APIKey: apiKey, BaseURL: server.URL}, providers.ProviderOptions{})
 		resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
 			Model:    Model,
-			Messages: []core.Message{{Role: "user", Content: "hi"}},
+			Messages: []core.Message{{Role: "user", Content: Prompt}},
 		})
 		if err != nil {
 			t.Fatalf("ChatCompletion() error = %v", err)
 		}
 		req := capture.Last(t)
 		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
-		if got := req.JSON(t)["model"]; got != Model {
-			t.Errorf("request model = %#v, want %q", got, Model)
-		}
+		assertChatRequest(t, req.JSON(t), false)
 		if resp.Model != Model || len(resp.Choices) != 1 || resp.Choices[0].Message.Content != Reply {
 			t.Errorf("unexpected response: %+v", resp)
 		}
@@ -123,7 +124,7 @@ func AssertChatCompatible(t *testing.T, p ChatCompatible) {
 		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
 		stream, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{
 			Model:    Model,
-			Messages: []core.Message{{Role: "user", Content: "hi"}},
+			Messages: []core.Message{{Role: "user", Content: Prompt}},
 		})
 		if err != nil {
 			t.Fatalf("StreamChatCompletion() error = %v", err)
@@ -135,12 +136,8 @@ func AssertChatCompatible(t *testing.T, p ChatCompatible) {
 		}
 		req := capture.Last(t)
 		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
-		if sent := req.JSON(t); sent["model"] != Model || sent["stream"] != true {
-			t.Errorf("stream request body = %#v, want model %q and stream=true", sent, Model)
-		}
-		if !strings.Contains(string(body), "data: [DONE]") {
-			t.Errorf("stream body = %q, want SSE terminator", body)
-		}
+		assertChatRequest(t, req.JSON(t), true)
+		assertStreamBody(t, body, Reply, "data: [DONE]")
 	})
 
 	t.Run("list models", func(t *testing.T) {
@@ -159,24 +156,43 @@ func AssertChatCompatible(t *testing.T, p ChatCompatible) {
 	t.Run("responses translate to chat completions", func(t *testing.T) {
 		server, capture := JSONServer(t, http.StatusOK, ChatCompletionJSON)
 		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
-		resp, err := provider.Responses(context.Background(), &core.ResponsesRequest{Model: Model, Input: "hi"})
+		resp, err := provider.Responses(context.Background(), &core.ResponsesRequest{Model: Model, Input: Prompt})
 		if err != nil {
 			t.Fatalf("Responses() error = %v", err)
 		}
 		req := capture.Last(t)
 		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
-		if got := req.JSON(t)["model"]; got != Model {
-			t.Errorf("request model = %#v, want %q", got, Model)
-		}
+		assertChatRequest(t, req.JSON(t), false)
 		if resp.Object != "response" || resp.Status != "completed" {
 			t.Errorf("response object/status = %q/%q, want response/completed", resp.Object, resp.Status)
 		}
+		if got := outputText(resp); got != Reply {
+			t.Errorf("response output text = %q, want %q", got, Reply)
+		}
+	})
+
+	t.Run("stream responses translate to chat completions", func(t *testing.T) {
+		server, capture := SSEServer(t, ChatChunkSSE)
+		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		stream, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{Model: Model, Input: Prompt})
+		if err != nil {
+			t.Fatalf("StreamResponses() error = %v", err)
+		}
+		defer stream.Close()
+		body, err := io.ReadAll(stream)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		req := capture.Last(t)
+		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
+		assertChatRequest(t, req.JSON(t), true)
+		assertStreamBody(t, body, "response.output_text.delta", Reply, "data: [DONE]")
 	})
 
 	t.Run("embeddings", func(t *testing.T) {
 		server, capture := JSONServer(t, http.StatusOK, EmbeddingsJSON)
 		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
-		resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{Model: Model, Input: "hi"})
+		resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{Model: Model, Input: Prompt})
 		if !p.Embeddings {
 			AssertUnsupported(t, err)
 			if capture.Count() != 0 {
@@ -187,9 +203,20 @@ func AssertChatCompatible(t *testing.T, p ChatCompatible) {
 		if err != nil {
 			t.Fatalf("Embeddings() error = %v", err)
 		}
-		assertUpstream(t, capture.Last(t), http.MethodPost, "/embeddings", p.AuthHeader, wantAuth)
+		req := capture.Last(t)
+		assertUpstream(t, req, http.MethodPost, "/embeddings", p.AuthHeader, wantAuth)
+		if sent := req.JSON(t); sent["model"] != Model || sent["input"] != Prompt {
+			t.Errorf("embeddings request = %#v, want model %q and input %q", sent, Model, Prompt)
+		}
 		if len(resp.Data) != 1 {
-			t.Errorf("embeddings = %+v, want one vector", resp.Data)
+			t.Fatalf("embeddings = %+v, want one vector", resp.Data)
+		}
+		var vector []float64
+		if err := json.Unmarshal(resp.Data[0].Embedding, &vector); err != nil {
+			t.Fatalf("embedding vector %s: %v", resp.Data[0].Embedding, err)
+		}
+		if len(vector) != 2 || vector[0] != 0.1 || vector[1] != 0.2 {
+			t.Errorf("embedding vector = %v, want [0.1 0.2]", vector)
 		}
 	})
 }
@@ -227,6 +254,55 @@ func AssertNoNativeSurfaces(t testing.TB, provider any) {
 	if _, ok := provider.(core.AudioProvider); ok {
 		t.Error("provider should not implement core.AudioProvider")
 	}
+}
+
+// assertChatRequest checks a translated chat completions body: the model,
+// the stream flag, and that the user prompt survived translation.
+func assertChatRequest(t testing.TB, sent map[string]any, stream bool) {
+	t.Helper()
+	if sent["model"] != Model {
+		t.Errorf("request model = %#v, want %q", sent["model"], Model)
+	}
+	if stream && sent["stream"] != true {
+		t.Errorf("request stream = %#v, want true", sent["stream"])
+	}
+	messages, _ := sent["messages"].([]any)
+	found := false
+	for _, m := range messages {
+		msg, _ := m.(map[string]any)
+		if msg["role"] == "user" && msg["content"] == Prompt {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("request messages = %#v, want a user message %q", sent["messages"], Prompt)
+	}
+}
+
+// assertStreamBody checks that each expected fragment appears in the stream.
+func assertStreamBody(t testing.TB, body []byte, want ...string) {
+	t.Helper()
+	for _, fragment := range want {
+		if !strings.Contains(string(body), fragment) {
+			t.Errorf("stream body = %q, want %q", body, fragment)
+		}
+	}
+}
+
+// outputText concatenates the assistant output_text parts of a response.
+func outputText(resp *core.ResponsesResponse) string {
+	var text strings.Builder
+	for _, item := range resp.Output {
+		if item.Type != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if part.Type == "output_text" {
+				text.WriteString(part.Text)
+			}
+		}
+	}
+	return text.String()
 }
 
 func assertUpstream(t testing.TB, req Recorded, method, path, authHeader, wantAuth string) {

--- a/internal/providers/providertest/chat_compatible.go
+++ b/internal/providers/providertest/chat_compatible.go
@@ -1,0 +1,243 @@
+package providertest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+)
+
+// ChatCompletionJSON is a minimal OpenAI-shaped chat completion reply whose
+// model is Model and whose single choice says Reply.
+const ChatCompletionJSON = `{
+	"id":"chatcmpl-test",
+	"object":"chat.completion",
+	"created":1677652288,
+	"model":"` + Model + `",
+	"choices":[{"index":0,"message":{"role":"assistant","content":"` + Reply + `"},"finish_reason":"stop"}],
+	"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}
+}`
+
+// ChatChunkSSE is a one-chunk chat completion stream ending in [DONE].
+const ChatChunkSSE = "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"model\":\"" + Model + "\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"" + Reply + "\"}}]}\n\ndata: [DONE]\n\n"
+
+// ModelsJSON lists Model as the only available model.
+const ModelsJSON = `{"object":"list","data":[{"id":"` + Model + `","object":"model","owned_by":"test"}]}`
+
+// EmbeddingsJSON is a one-vector embeddings reply.
+const EmbeddingsJSON = `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"model":"` + Model + `","usage":{"prompt_tokens":2,"total_tokens":2}}`
+
+// Model and Reply are the model ID and assistant text used by the fixtures.
+const (
+	Model = "test-model"
+	Reply = "hello"
+)
+
+// ChatCompatible describes a provider built on the shared OpenAI-compatible
+// adapter so AssertChatCompatible can check the contract every such provider
+// shares.
+type ChatCompatible struct {
+	// Registration is the provider's factory registration.
+	Registration providers.Registration
+	// Type is the expected Registration.Type.
+	Type string
+	// DefaultBaseURL is the expected Registration.Discovery.DefaultBaseURL.
+	DefaultBaseURL string
+	// New is the provider's NewWithHTTPClient constructor.
+	New func(apiKey, baseURL string, client *http.Client, hooks llmclient.Hooks) core.Provider
+	// Embeddings reports whether the provider forwards embeddings upstream.
+	// When false the helper asserts a typed invalid-request error and no
+	// upstream call.
+	Embeddings bool
+	// AuthHeader and AuthPrefix describe how the API key is sent. They
+	// default to Authorization and "Bearer ".
+	AuthHeader string
+	AuthPrefix string
+}
+
+// AssertChatCompatible checks the contract shared by providers that embed
+// the OpenAI-compatible adapter: registration metadata, constructor safety,
+// and that chat, streaming, model listing, Responses translation, and
+// embeddings reach the expected upstream paths with the API key attached.
+func AssertChatCompatible(t *testing.T, p ChatCompatible) {
+	t.Helper()
+	if p.AuthHeader == "" {
+		p.AuthHeader = "Authorization"
+	}
+	if p.AuthPrefix == "" && p.AuthHeader == "Authorization" {
+		p.AuthPrefix = "Bearer "
+	}
+	const apiKey = "test-api-key"
+	wantAuth := p.AuthPrefix + apiKey
+
+	t.Run("registration", func(t *testing.T) {
+		if p.Registration.Type != p.Type {
+			t.Errorf("Registration.Type = %q, want %q", p.Registration.Type, p.Type)
+		}
+		if p.Registration.New == nil {
+			t.Fatal("Registration.New is nil")
+		}
+		if got := p.Registration.Discovery.DefaultBaseURL; got != p.DefaultBaseURL {
+			t.Errorf("Registration.Discovery.DefaultBaseURL = %q, want %q", got, p.DefaultBaseURL)
+		}
+		provider := p.Registration.New(providers.ProviderConfig{APIKey: apiKey}, providers.ProviderOptions{})
+		if provider == nil {
+			t.Fatal("Registration.New returned nil")
+		}
+	})
+
+	t.Run("constructor tolerates nil client and zero hooks", func(t *testing.T) {
+		if provider := p.New(apiKey, "http://example.invalid", nil, llmclient.Hooks{}); provider == nil {
+			t.Fatal("NewWithHTTPClient(nil client) returned nil")
+		}
+	})
+
+	t.Run("chat completion", func(t *testing.T) {
+		server, capture := JSONServer(t, http.StatusOK, ChatCompletionJSON)
+		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+			Model:    Model,
+			Messages: []core.Message{{Role: "user", Content: "hi"}},
+		})
+		if err != nil {
+			t.Fatalf("ChatCompletion() error = %v", err)
+		}
+		req := capture.Last(t)
+		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
+		if got := req.JSON(t)["model"]; got != Model {
+			t.Errorf("request model = %#v, want %q", got, Model)
+		}
+		if resp.Model != Model || len(resp.Choices) != 1 || resp.Choices[0].Message.Content != Reply {
+			t.Errorf("unexpected response: %+v", resp)
+		}
+	})
+
+	t.Run("stream chat completion", func(t *testing.T) {
+		server, capture := SSEServer(t, ChatChunkSSE)
+		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		stream, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{
+			Model:    Model,
+			Messages: []core.Message{{Role: "user", Content: "hi"}},
+		})
+		if err != nil {
+			t.Fatalf("StreamChatCompletion() error = %v", err)
+		}
+		defer stream.Close()
+		body, err := io.ReadAll(stream)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		req := capture.Last(t)
+		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
+		if sent := req.JSON(t); sent["model"] != Model || sent["stream"] != true {
+			t.Errorf("stream request body = %#v, want model %q and stream=true", sent, Model)
+		}
+		if !strings.Contains(string(body), "data: [DONE]") {
+			t.Errorf("stream body = %q, want SSE terminator", body)
+		}
+	})
+
+	t.Run("list models", func(t *testing.T) {
+		server, capture := JSONServer(t, http.StatusOK, ModelsJSON)
+		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		resp, err := provider.ListModels(context.Background())
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+		assertUpstream(t, capture.Last(t), http.MethodGet, "/models", p.AuthHeader, wantAuth)
+		if len(resp.Data) != 1 || resp.Data[0].ID != Model {
+			t.Errorf("models = %+v, want one model %q", resp.Data, Model)
+		}
+	})
+
+	t.Run("responses translate to chat completions", func(t *testing.T) {
+		server, capture := JSONServer(t, http.StatusOK, ChatCompletionJSON)
+		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		resp, err := provider.Responses(context.Background(), &core.ResponsesRequest{Model: Model, Input: "hi"})
+		if err != nil {
+			t.Fatalf("Responses() error = %v", err)
+		}
+		req := capture.Last(t)
+		assertUpstream(t, req, http.MethodPost, "/chat/completions", p.AuthHeader, wantAuth)
+		if got := req.JSON(t)["model"]; got != Model {
+			t.Errorf("request model = %#v, want %q", got, Model)
+		}
+		if resp.Object != "response" || resp.Status != "completed" {
+			t.Errorf("response object/status = %q/%q, want response/completed", resp.Object, resp.Status)
+		}
+	})
+
+	t.Run("embeddings", func(t *testing.T) {
+		server, capture := JSONServer(t, http.StatusOK, EmbeddingsJSON)
+		provider := p.New(apiKey, server.URL, server.Client(), llmclient.Hooks{})
+		resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{Model: Model, Input: "hi"})
+		if !p.Embeddings {
+			AssertUnsupported(t, err)
+			if capture.Count() != 0 {
+				t.Errorf("upstream received %d requests, want 0 (embeddings must not be forwarded)", capture.Count())
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("Embeddings() error = %v", err)
+		}
+		assertUpstream(t, capture.Last(t), http.MethodPost, "/embeddings", p.AuthHeader, wantAuth)
+		if len(resp.Data) != 1 {
+			t.Errorf("embeddings = %+v, want one vector", resp.Data)
+		}
+	})
+}
+
+// AssertUnsupported checks that err is the typed invalid-request error a
+// provider returns for a surface it does not offer.
+func AssertUnsupported(t testing.TB, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("error = nil, want typed unsupported error")
+	}
+	var gwErr *core.GatewayError
+	if !errors.As(err, &gwErr) {
+		t.Fatalf("error type = %T, want *core.GatewayError", err)
+	}
+	if gwErr.Type != core.ErrorTypeInvalidRequest {
+		t.Errorf("error Type = %v, want %v", gwErr.Type, core.ErrorTypeInvalidRequest)
+	}
+	if gwErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("error StatusCode = %d, want %d", gwErr.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// AssertNoNativeSurfaces checks that provider does not advertise the optional
+// native batch, file, or audio interfaces, so a provider built on the shared
+// adapter cannot accidentally claim capabilities its upstream lacks.
+func AssertNoNativeSurfaces(t testing.TB, provider any) {
+	t.Helper()
+	if _, ok := provider.(core.NativeBatchProvider); ok {
+		t.Error("provider should not implement core.NativeBatchProvider")
+	}
+	if _, ok := provider.(core.NativeFileProvider); ok {
+		t.Error("provider should not implement core.NativeFileProvider")
+	}
+	if _, ok := provider.(core.AudioProvider); ok {
+		t.Error("provider should not implement core.AudioProvider")
+	}
+}
+
+func assertUpstream(t testing.TB, req Recorded, method, path, authHeader, wantAuth string) {
+	t.Helper()
+	if req.Method != method {
+		t.Errorf("upstream method = %s, want %s", req.Method, method)
+	}
+	if req.Path != path {
+		t.Errorf("upstream path = %q, want %q", req.Path, path)
+	}
+	if got := req.Header.Get(authHeader); got != wantAuth {
+		t.Errorf("upstream %s header = %q, want %q", authHeader, got, wantAuth)
+	}
+}

--- a/internal/providers/providertest/providertest_test.go
+++ b/internal/providers/providertest/providertest_test.go
@@ -1,0 +1,53 @@
+package providertest
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_RecordsRequestsAndKeepsBodyReadable(t *testing.T) {
+	var seen string
+	server, capture := Server(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seen = string(body)
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/x?q=1", strings.NewReader(`{"a":1}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer k")
+	resp, err := server.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	assert.Equal(t, `{"a":1}`, seen)
+	require.Equal(t, 1, capture.Count())
+	last := capture.Last(t)
+	assert.Equal(t, http.MethodPost, last.Method)
+	assert.Equal(t, "/v1/x", last.Path)
+	assert.Equal(t, "1", last.Query.Get("q"))
+	assert.Equal(t, "Bearer k", last.Header.Get("Authorization"))
+	assert.Equal(t, float64(1), last.JSON(t)["a"])
+}
+
+func TestRouteServer_DispatchesByPath(t *testing.T) {
+	server, capture := RouteServer(t, map[string]http.HandlerFunc{
+		"/ok": func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) },
+	})
+	resp, err := http.Get(server.URL + "/ok")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	resp, err = http.Get(server.URL + "/missing")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Len(t, capture.All(), 2)
+}

--- a/internal/providers/providertest/server.go
+++ b/internal/providers/providertest/server.go
@@ -21,6 +21,9 @@ type Recorded struct {
 	Query  url.Values
 	Header http.Header
 	Body   []byte
+	// ReadErr is the error, if any, from reading the request body; Body then
+	// holds whatever arrived before it.
+	ReadErr error
 }
 
 // JSON decodes the recorded body as a JSON object.
@@ -53,7 +56,8 @@ func (c *Capture) All() []Recorded {
 	return append([]Recorded(nil), c.requests...)
 }
 
-// Last returns the most recent request, failing the test when none arrived.
+// Last returns the most recent request, failing the test when none arrived
+// or when its body could not be read in full.
 func (c *Capture) Last(t testing.TB) Recorded {
 	t.Helper()
 	c.mu.Lock()
@@ -61,20 +65,25 @@ func (c *Capture) Last(t testing.TB) Recorded {
 	if len(c.requests) == 0 {
 		t.Fatal("providertest: upstream received no requests")
 	}
-	return c.requests[len(c.requests)-1]
+	last := c.requests[len(c.requests)-1]
+	if last.ReadErr != nil {
+		t.Fatalf("providertest: reading upstream request body: %v", last.ReadErr)
+	}
+	return last
 }
 
 func (c *Capture) record(r *http.Request) {
-	body, _ := io.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.requests = append(c.requests, Recorded{
-		Method: r.Method,
-		Path:   r.URL.Path,
-		Query:  r.URL.Query(),
-		Header: r.Header.Clone(),
-		Body:   body,
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Query:   r.URL.Query(),
+		Header:  r.Header.Clone(),
+		Body:    body,
+		ReadErr: err,
 	})
 }
 

--- a/internal/providers/providertest/server.go
+++ b/internal/providers/providertest/server.go
@@ -1,0 +1,130 @@
+// Package providertest holds helpers for provider adapter tests: upstream
+// test servers that record what the adapter sent, and a shared contract
+// check for providers built on the OpenAI-compatible adapter.
+package providertest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+// Recorded is one upstream request as the test server received it.
+type Recorded struct {
+	Method string
+	Path   string
+	Query  url.Values
+	Header http.Header
+	Body   []byte
+}
+
+// JSON decodes the recorded body as a JSON object.
+func (r Recorded) JSON(t testing.TB) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(r.Body, &out); err != nil {
+		t.Fatalf("providertest: request body is not a JSON object: %v\nbody: %s", err, r.Body)
+	}
+	return out
+}
+
+// Capture collects the requests an upstream test server received.
+type Capture struct {
+	mu       sync.Mutex
+	requests []Recorded
+}
+
+// Count returns how many requests the server received.
+func (c *Capture) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.requests)
+}
+
+// All returns every recorded request in arrival order.
+func (c *Capture) All() []Recorded {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]Recorded(nil), c.requests...)
+}
+
+// Last returns the most recent request, failing the test when none arrived.
+func (c *Capture) Last(t testing.TB) Recorded {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.requests) == 0 {
+		t.Fatal("providertest: upstream received no requests")
+	}
+	return c.requests[len(c.requests)-1]
+}
+
+func (c *Capture) record(r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requests = append(c.requests, Recorded{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Query:  r.URL.Query(),
+		Header: r.Header.Clone(),
+		Body:   body,
+	})
+}
+
+// Server starts a test server that records each request before handing it
+// to handler. The body stays readable by handler. The server closes when the
+// test ends.
+func Server(t testing.TB, handler http.HandlerFunc) (*httptest.Server, *Capture) {
+	t.Helper()
+	capture := &Capture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.record(r)
+		if handler != nil {
+			handler(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, capture
+}
+
+// JSONServer starts a recording server that answers every request with
+// status and body as application/json.
+func JSONServer(t testing.TB, status int, body string) (*httptest.Server, *Capture) {
+	t.Helper()
+	return Server(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	})
+}
+
+// SSEServer starts a recording server that answers every request with body
+// as text/event-stream.
+func SSEServer(t testing.TB, body string) (*httptest.Server, *Capture) {
+	t.Helper()
+	return Server(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, body)
+	})
+}
+
+// RouteServer starts a recording server that dispatches on request path and
+// answers unknown paths with 404. Each handler receives the recorder-wrapped
+// request.
+func RouteServer(t testing.TB, routes map[string]http.HandlerFunc) (*httptest.Server, *Capture) {
+	t.Helper()
+	return Server(t, func(w http.ResponseWriter, r *http.Request) {
+		if handler, ok := routes[r.URL.Path]; ok {
+			handler(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	})
+}


### PR DESCRIPTION
Adds two small test helper packages so handler and provider tests can stop repeating their setup:

- `internal/echotest`: builds an echo context and recorder from a method, target, and body (string, bytes, reader, or JSON-encoded value), with options for headers, path values, and context values, plus a generic JSON response decoder.
- `internal/providers/providertest`: recording upstream test servers (`Server`, `JSONServer`, `SSEServer`, `RouteServer`) that capture method, path, query, headers, and body, and `AssertChatCompatible`, a shared contract check for providers built on the OpenAI-compatible adapter (registration, constructors, chat, streaming, model listing, Responses translation, embeddings).

No production code changes. Follow-up PRs adopt these helpers per package and convert hand-rolled assertions to testify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added reusable helpers for constructing requests, configuring contexts, recording responses, and decoding test results.
  * Added provider test servers that capture requests, support JSON and streaming responses, and dispatch routes.
  * Added shared compatibility checks for provider registration, chat, streaming, model listing, response translation, embeddings, and unsupported capabilities.
  * Added coverage for request bodies, headers, paths, query parameters, JSON payloads, response status, and route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->